### PR TITLE
[UI] Add toggle for vulnerability demos

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -10,6 +10,76 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <style>
+        /* Basic Toggle Switch CSS */
+        .ui-vulnerability-features-toggle-container {
+            display: flex;
+            align-items: center;
+            margin-left: 20px;
+            padding: 6px 12px;
+            background-color: rgba(0,0,0,0.15);
+            border-radius: 20px;
+            border: 1px solid rgba(255,255,255,0.2);
+        }
+        .ui-vulnerability-features-toggle-container label {
+            margin-right: 10px;
+            font-size: 0.8rem;
+            color: #e0e0e0;
+            cursor: pointer;
+            font-weight: 500;
+        }
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 40px;
+            height: 20px;
+        }
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #757575;
+            transition: .3s;
+            border-radius: 20px;
+        }
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 14px;
+            width: 14px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            transition: .3s;
+            border-radius: 50%;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        }
+        input:checked + .slider {
+            background-color: var(--warning-color);
+        }
+        input:focus + .slider {
+            box-shadow: 0 0 1px var(--warning-color);
+        }
+        input:checked + .slider:before {
+            transform: translateX(20px);
+        }
+        .toggle-status-text {
+            font-size: 0.75rem;
+            margin-left: 8px;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+        .ui-features-enabled-text { color: var(--warning-color); }
+        .ui-features-disabled-text { color: #b0bec5; }
+    </style>
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -22,6 +92,15 @@
             </a>
             <div id="dynamic-nav-links">
                 <!-- Dynamic links will be inserted here by JavaScript -->
+            </div>
+            <!-- Add UI Vulnerability Features Toggle Here -->
+            <div class="ui-vulnerability-features-toggle-container">
+                <label for="ui-vulnerability-features-toggle-switch">UI Demos:</label>
+                <label class="switch">
+                    <input type="checkbox" id="ui-vulnerability-features-toggle-switch">
+                    <span class="slider"></span>
+                </label>
+                <span id="ui-vulnerability-features-toggle-status" class="toggle-status-text"></span>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add navbar toggle to enable or disable demo UI
- store toggle state in localStorage and update navbar logic
- hide/show vulnerability demo sections via new JS helpers

## Test Plan
- `pytest tests/ --maxfail=1 --disable-warnings -q` *(fails: Failed to start API server)*
- `npx playwright test frontend/e2e-tests/ --timeout=60000` *(fails: dependency error)*
