### PR TITLE
[Config] Add worker scaling settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ EXPOSE 80
 
 # Define environment variable
 ENV PYTHONPATH=/app
+# Default worker count can be overridden at runtime
+ENV UVICORN_WORKERS=4
 
 # Command to run supervisor, which will manage both services
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ This often manifests as Mass Assignment or Parameter Pollution, where users can 
     ```
     The API will be accessible at `http://localhost:8000`.
 
+    Set `UVICORN_WORKERS` to control the number of worker processes:
+    ```sh
+    docker run -d -p 8000:8000 -e UVICORN_WORKERS=4 \
+      --name radware-vuln-api vulnerable-ecommerce-api
+    ```
+
 #### Running Locally (Alternative)
 
 1.  **Clone the Repository (if applicable):**

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,7 @@ server {
         rewrite ^/api(/.*)$ $1 break;
         proxy_pass http://localhost:8000;
         proxy_set_header Host $host;
+        proxy_read_timeout 120s;
     }
 
     # Serve static files directly

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -2,7 +2,11 @@
 
 # Start the backend FastAPI app (run in background)
 echo "Starting backend API on port 8000..."
-python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload &
+if [ -n "$UVICORN_WORKERS" ]; then
+  python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers "$UVICORN_WORKERS" --reload &
+else
+  python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload &
+fi
 BACKEND_PID=$!
 
 # Wait a moment for backend to initialize

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,7 +12,8 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:backend]
-command=uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config app/log_conf.json --no-access-log
+environment=UVICORN_WORKERS=1
+command=uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config app/log_conf.json --no-access-log --workers %(ENV_UVICORN_WORKERS)s
 directory=/app
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- allow scaling Uvicorn workers with `UVICORN_WORKERS`
- document new environment variable
- support worker env var in local dev script
- extend nginx timeout for slow requests

## Test Plan
- `pytest tests/ --maxfail=1 --disable-warnings -q`
- `npx playwright test frontend/e2e-tests/ --timeout=60000`
