### PR TITLE
[Admin] Always show demo controls

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -347,7 +347,8 @@ function updateUIVulnerabilityFeaturesDisplay() {
     // --- Admin Page (`admin_products.html`) ---
     if (document.querySelector('.admin-section h1')?.textContent === 'Admin Dashboard') {
         const isRealAdmin = currentUser && currentUser.is_admin;
-        toggleVisibilityBySelector('.parameter-pollution-controls', uiVulnerabilityFeaturesEnabled);
+        const ppSection = document.querySelector('.parameter-pollution-controls');
+        if (ppSection) ppSection.style.display = 'block';
         toggleVisibilityBySelector('.add-product-section', isRealAdmin || uiVulnerabilityFeaturesEnabled);
         toggleVisibilityBySelector('.update-stock-section', isRealAdmin || uiVulnerabilityFeaturesEnabled);
         toggleVisibilityBySelector('.delete-user-section', isRealAdmin || uiVulnerabilityFeaturesEnabled);
@@ -358,7 +359,7 @@ function updateUIVulnerabilityFeaturesDisplay() {
             const revealInternalCheckbox = document.getElementById('reveal-internal');
             const adminChecked = adminEscalationCheckbox ? adminEscalationCheckbox.checked : false;
             const internalChecked = revealInternalCheckbox ? revealInternalCheckbox.checked : false;
-            adminVulnerabilityBanner.style.display = (uiVulnerabilityFeaturesEnabled && (adminChecked || internalChecked)) ? 'block' : 'none';
+            adminVulnerabilityBanner.style.display = (adminChecked || internalChecked) ? 'block' : 'none';
         }
         if (typeof fetchAdminProducts === "function") {
             fetchAdminProducts();

--- a/frontend/templates/admin_products.html
+++ b/frontend/templates/admin_products.html
@@ -21,24 +21,22 @@
     <h2>Products Management</h2>
 
     <!-- Parameter Pollution Demo Section -->
-    <div class="parameter-pollution-controls">
-        <h3>Parameter Pollution Demo Options</h3>
+    <div class="parameter-pollution-controls vulnerability-demo-section card-style">
+        <h2><i class="fas fa-filter-circle-dollar"></i> Parameter Pollution Demo Options</h2>
         <p>These options demonstrate API parameter pollution vulnerabilities by adding extra query parameters to the product list request. Observe the "Demo URL" to see the effect.</p>
-        <div class="checkbox-group">
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="admin-escalation" name="admin_escalation">
-                <label class="form-check-label" for="admin-escalation">
-                    <strong>Escalate to Admin Privileges</strong> - Adds a second <code>role=admin</code> parameter to bypass authorization checks (simulating BFLA).
-                </label>
-            </div>
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="reveal-internal" name="reveal_internal">
-                <label class="form-check-label" for="reveal-internal">
-                    <strong>Show Internal Products</strong> - Adds a <code>status=internal</code> parameter to view products not normally visible to regular users.
-                </label>
-            </div>
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="admin-escalation" name="admin_escalation">
+            <label class="form-check-label" for="admin-escalation">
+                <strong>Escalate to Admin Privileges</strong> - Adds a second <code>role=admin</code> parameter to bypass authorization checks (simulating BFLA).
+            </label>
         </div>
-        <div class="demo-url-display">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="reveal-internal" name="reveal_internal">
+            <label class="form-check-label" for="reveal-internal">
+                <strong>Show Internal Products</strong> - Adds a <code>status=internal</code> parameter to view products not normally visible to regular users.
+            </label>
+        </div>
+        <div class="demo-url-display mt-2">
             <strong>Demo URL:</strong> <span id="constructed-url-display">/products?role=user</span>
             <button id="copy-constructed-url" class="btn btn-sm btn-secondary">Copy URL</button>
         </div>
@@ -53,8 +51,8 @@
     </div>
 
         <div class="add-product-section">
-            <h3>Add New Product (BFLA Demo)</h3>
-        <p class="helper-text">This form demonstrates adding a product. As a regular user, this action should typically be restricted. If successful, it indicates a BFLA vulnerability.</p>
+            <h3 id="add-product-header"><span class="exploit-indicator">BFLA</span> Demo: Add New Product</h3>
+        <p id="add-product-helper" class="helper-text">This form demonstrates adding a product as a non-admin. If successful, it indicates a BFLA vulnerability.</p>
         <form id="add-product-form">
             <div class="form-group">
                 <label for="new-product-name">Product Name:</label>
@@ -74,18 +72,20 @@
                     <input type="text" id="new-product-category" class="form-control">
                 </div>
             </div>
-             <div class="form-group">
-                <label for="new-product-internal-status">Internal Status (Optional):</label>
-                <input type="text" id="new-product-internal-status" class="form-control" placeholder="e.g., 'pending_review', 'backordered'">
-                <small class="helper-text">This field is typically for internal use and might not be exposed to regular users.</small>
+            <div class="parameter-pollution-create">
+                <h4>Parameter Pollution Demo: Set Internal Status on Create</h4>
+                <div class="form-group">
+                    <label for="new-product-internal-status">Internal Status (Optional):</label>
+                    <input type="text" id="new-product-internal-status" class="form-control" placeholder="e.g., 'pending_review', 'backordered'">
+                </div>
             </div>
-            <button type="submit" class="btn btn-primary btn-exploit">Add Product (Demo Exploit)</button>
+            <button type="submit" id="add-product-submit" class="btn btn-warning btn-exploit">Add Product (Demo Exploit)</button>
         </form>
     </div>
 
     <div class="update-stock-section" style="margin-top: 30px;">
-        <h3>Update Product Stock (BFLA Demo)</h3>
-        <p class="helper-text">Any user can modify stock quantities without authorization.</p>
+        <h3 id="update-stock-header"><span class="exploit-indicator">BFLA</span> Demo: Update Product Stock</h3>
+        <p id="update-stock-helper" class="helper-text">Any user can modify stock quantities without authorization.</p>
         <form id="update-stock-form">
             <div class="form-group">
                 <label for="stock-product-id">Product ID:</label>
@@ -95,19 +95,19 @@
                 <label for="new-stock-qty">New Quantity:</label>
                 <input type="number" id="new-stock-qty" class="form-control" min="0">
             </div>
-            <button type="submit" class="btn btn-warning btn-exploit">Update Stock</button>
+            <button type="submit" id="update-stock-submit" class="btn btn-warning btn-exploit">Update Stock (Demo Exploit)</button>
         </form>
     </div>
 
     <div class="delete-user-section" style="margin-top: 30px;">
-        <h3>Delete User (BFLA Demo)</h3>
-        <p class="helper-text">Demonstrates deleting any user via <code>DELETE /api/users/&lt;id&gt;</code>.</p>
+        <h3><span class="exploit-indicator">BFLA</span> Demo: Delete User Account</h3>
+        <p class="helper-text">Demonstrates deleting any user. This action should be restricted to administrators.</p>
         <form id="delete-user-form">
             <div class="form-group">
                 <label for="delete-user-id">Target User ID:</label>
                 <input type="text" id="delete-user-id" class="form-control" placeholder="User ID">
             </div>
-            <button type="submit" class="btn btn-danger btn-exploit">Delete User</button>
+            <button type="submit" class="btn btn-danger btn-exploit">Delete User (Demo Exploit)</button>
         </form>
     </div>
 


### PR DESCRIPTION
## Summary
- restyle Parameter Pollution demo controls on admin page
- update admin demo sections to reflect admin vs. BFLA actions
- make demo controls always visible regardless of UI toggle
- adjust admin JavaScript accordingly

## Testing
- `pytest tests/ --maxfail=1 --disable-warnings -q` *(fails: Failed to start API server)*
- `npx playwright test frontend/e2e-tests/ --timeout=60000` *(fails: ImportError: cannot import name 'url_quote')*