### PR TITLE
[Orders] Enhance BOLA user selection

### DIFF
--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -4997,4 +4997,10 @@ nav.breadcrumb .current-page {
     margin-top: 5px;
 }
 
+/* Highlight selected victim in user lists */
+.selected-victim-item {
+    background-color: var(--warning-bg);
+    border-color: var(--warning-color);
+}
+
 /* ...existing code... */

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -1532,9 +1532,23 @@ function initOrdersPage() {
 
     viewingUserIdInput.value = bolaTargetUserIdFromStorage || currentUser.user_id;
     
-    const targetUserIdFieldOnPage = document.getElementById('target-user-id'); 
+    const targetUserIdFieldOnPage = document.getElementById('target-user-id');
+    const detailUserIdInput = document.getElementById('detail-user-id');
+    const selectedViewSpan = document.getElementById('selected-target-view-orders');
+    const selectedDetailSpan = document.getElementById('selected-target-order-detail');
     if (targetUserIdFieldOnPage && bolaTargetUserIdFromStorage) {
-        targetUserIdFieldOnPage.value = bolaTargetUserIdFromStorage; 
+        targetUserIdFieldOnPage.value = bolaTargetUserIdFromStorage;
+        if (selectedViewSpan) {
+            const dName = bolaTargetUsernameFromStorage || bolaTargetUserIdFromStorage.substring(0,8)+"...";
+            selectedViewSpan.textContent = `(Selected: ${dName})`;
+        }
+    }
+    if (detailUserIdInput && bolaTargetUserIdFromStorage) {
+        detailUserIdInput.value = bolaTargetUserIdFromStorage;
+        if (selectedDetailSpan) {
+            const dName = bolaTargetUsernameFromStorage || bolaTargetUserIdFromStorage.substring(0,8)+"...";
+            selectedDetailSpan.textContent = `(Selected: ${dName})`;
+        }
     }
 
     fetchAndDisplayOrders(); 
@@ -1573,6 +1587,39 @@ function initOrdersPage() {
             displayGlobalMessage('Returned to viewing your own orders.', 'info');
         });
     }
+
+    // Delegated listener for selecting a user from the list
+    document.addEventListener('click', function(e) {
+        const btn = e.target.closest('.select-user-for-orders-bola-btn');
+        if (!btn) return;
+        const selectedUserId = btn.dataset.userId;
+        const selectedUsername = btn.dataset.username;
+        if (targetUserIdFieldOnPage) targetUserIdFieldOnPage.value = selectedUserId;
+        if (detailUserIdInput) detailUserIdInput.value = selectedUserId;
+        if (selectedViewSpan) selectedViewSpan.textContent = `(Selected: ${selectedUsername})`;
+        if (selectedDetailSpan) selectedDetailSpan.textContent = `(Selected: ${selectedUsername})`;
+        const usersList = document.getElementById('users-list');
+        if (usersList) {
+            usersList.querySelectorAll('.selected-victim-item').forEach(item => item.classList.remove('selected-victim-item'));
+            const li = btn.closest('li');
+            if (li) li.classList.add('selected-victim-item');
+        }
+        displayGlobalMessage(`Target for BOLA order demos set to: ${selectedUsername} (ID: ${selectedUserId.substring(0,8)}...)`, 'info');
+    });
+
+    targetUserIdFieldOnPage?.addEventListener('input', function() {
+        if (!this.value.trim() && selectedViewSpan) {
+            selectedViewSpan.textContent = '';
+            const usersList = document.getElementById('users-list');
+            if (usersList) usersList.querySelectorAll('.selected-victim-item').forEach(item => item.classList.remove('selected-victim-item'));
+        }
+    });
+
+    detailUserIdInput?.addEventListener('input', function() {
+        if (!this.value.trim() && selectedDetailSpan) {
+            selectedDetailSpan.textContent = '';
+        }
+    });
 
     document.getElementById('list-users-btn')?.addEventListener('click', listUsersForOrders);
     document.getElementById('order-detail-form')?.addEventListener('submit', fetchOrderDetail);
@@ -2392,8 +2439,16 @@ async function listUsersForOrders() {
         listEl.innerHTML = '';
         users.forEach(u => {
             const li = document.createElement('li');
-            li.className = 'list-group-item';
-            li.textContent = `${u.username} (${u.user_id.substring(0,8)}...)`;
+            li.className = 'list-group-item d-flex justify-content-between align-items-center';
+            li.innerHTML = `<span>${u.username} (ID: <code>${u.user_id}</code>)</span>`;
+            if (!currentUser || u.user_id !== currentUser.user_id) {
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-sm btn-outline-primary select-user-for-orders-bola-btn';
+                btn.dataset.userId = u.user_id;
+                btn.dataset.username = u.username;
+                btn.textContent = 'Select';
+                li.appendChild(btn);
+            }
             listEl.appendChild(li);
         });
     } catch (error) {

--- a/frontend/templates/orders.html
+++ b/frontend/templates/orders.html
@@ -19,8 +19,8 @@
         <form id="view-orders-form">
              <input type="hidden" id="viewing-user-id-orders" value=""> <!-- Added hidden input for orders BOLA state -->
             <div class="form-group">
-                <label for="target-user-id">Enter User ID to View Orders:</label>
-                <input type="text" id="target-user-id" name="target-user-id" placeholder="Enter another user's ID" class="form-control vulnerability-input">
+                <label for="target-user-id">Enter User ID to View Orders: <span id="selected-target-view-orders" class="text-muted small" style="font-style: italic; margin-left: 5px;"></span></label>
+                <input type="text" id="target-user-id" name="target-user-id" placeholder="Enter another user's ID or select from list below" class="form-control vulnerability-input">
                 <small class="helper-text">Try user IDs from `prepopulated_data.json`.</small>
             </div>
             <button type="submit" class="btn-exploit">View Another User's Orders</button>
@@ -44,8 +44,8 @@
         <p>Retrieve a specific order for any user.</p>
         <form id="order-detail-form">
             <div class="form-group">
-                <label for="detail-user-id">Target User ID:</label>
-                <input type="text" id="detail-user-id" class="form-control vulnerability-input" placeholder="User ID">
+                <label for="detail-user-id">Target User ID: <span id="selected-target-order-detail" class="text-muted small" style="font-style: italic; margin-left: 5px;"></span></label>
+                <input type="text" id="detail-user-id" class="form-control vulnerability-input" placeholder="User ID (auto-fills from selection)">
             </div>
             <div class="form-group">
                 <label for="detail-order-id">Order ID:</label>


### PR DESCRIPTION
## Summary
- enable selecting a target user for BOLA demos on orders page
- highlight selected user in the list
- show selected username beside BOLA input labels

## Testing
- `pytest tests/ --maxfail=1 --disable-warnings -q`
- `npx playwright test frontend/e2e-tests/ --timeout=60000`