### PR TITLE
[UI] Protected entity messages

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -1,6 +1,8 @@
 # Testing and Quality Assurance Documentation
 
 This document provides comprehensive information about the testing suite, traffic generation capabilities, and stability enhancements for the Radware Vulnerable API.
+For details on the `is_protected` flag and how tests should handle protected records, see [docs/PROTECTED_ENTITIES_GUIDE.md](docs/PROTECTED_ENTITIES_GUIDE.md).
+
 
 ## Table of Contents
 1. [Testing Framework](#1-testing-framework)

--- a/docs/PROTECTED_ENTITIES_GUIDE.md
+++ b/docs/PROTECTED_ENTITIES_GUIDE.md
@@ -1,0 +1,54 @@
+# Protected Entities and Testing Guide
+
+This guide summarizes how the `is_protected` flag works and how to run the test suites for the Radware Vulnerable API project.
+
+## Why Protected Entities Exist
+
+The repository contains certain users, products and profile data that are marked as **protected**. These records are defined in `prepopulated_data.json` and documented in [PROTECTED_ENTITIES.md](../PROTECTED_ENTITIES.md).
+
+Key goals of the protected entity system include:
+
+1. **Flow Stability** – automated demos rely on these records to always exist.
+2. **Predictable Demos** – common walkthroughs reference the same data.
+3. **WAAP Learning** – security tools can learn normal behavior from stable data.
+4. **User Guidance** – attempts to delete or heavily modify protected items return an HTTP 403 with a message directing testers toward non‑protected records.
+
+All newly created entities are *not* protected and may be freely modified or deleted to demonstrate vulnerabilities.
+
+## Writing and Running Tests
+
+The project uses **pytest** for backend tests and **Playwright** for frontend end‑to‑end tests. These commands are also listed in `AGENTS.md`.
+
+### Environment Setup
+
+```sh
+python -m venv .venv
+source .venv/bin/activate  # On Windows use .venv\Scripts\activate
+pip install -r requirements.txt pytest httpx pytest-asyncio
+```
+
+### Running Backend Tests
+
+Run functional tests:
+```sh
+pytest tests/test_functional.py --maxfail=1 --disable-warnings -q
+```
+
+Run vulnerability tests:
+```sh
+pytest tests/test_vulnerabilities.py --maxfail=1 --disable-warnings -q
+```
+
+### Running Frontend Tests
+
+```sh
+npx playwright test frontend/e2e-tests/ --timeout=60000
+```
+
+Alternatively, execute `./verify.sh` to set up the environment, start the API server, run both pytest suites, and generate brief traffic before shutting the server down.
+
+## Expected Test Behavior for Protected Entities
+
+When tests attempt destructive actions (such as deleting a user or product) against a protected record, the API should respond with **403 Forbidden** and an explanatory message. Operations against non‑protected entities should still succeed, demonstrating the vulnerabilities.
+
+Refer to [PROTECTED_ENTITIES.md](../PROTECTED_ENTITIES.md) for the complete list of protected records and tips on choosing non‑protected items for your tests.

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -308,7 +308,7 @@ footer {
     top: 20px;
     right: 20px;
     z-index: 9999;
-    width: 350px;
+    width: 420px;
     max-width: 90%;
 }
 
@@ -5004,3 +5004,21 @@ nav.breadcrumb .current-page {
 }
 
 /* ...existing code... */
+
+.protected-indicator {
+    font-size: 0.75em;
+    color: #777;
+    background-color: #f0f0f0;
+    padding: 2px 5px;
+    border-radius: 3px;
+    margin-left: 5px;
+    font-weight: normal;
+    cursor: help;
+}
+
+.protected-edit-note {
+    font-size: 0.85em;
+    color: var(--warning-text);
+    margin-top: 5px;
+}
+

--- a/frontend/templates/profile.html
+++ b/frontend/templates/profile.html
@@ -118,6 +118,9 @@
                         <label for="address-zip">Zip Code:</label>
                         <input type="text" id="address-zip" class="form-control" required>
                     </div>
+                    <div id="address-protected-note" class="protected-edit-note" style="display:none;">
+                        This is a protected address. Only limited modifications are allowed for demo purposes.
+                    </div>
                     <div class="form-actions">
                         <button type="submit" id="address-form-submit-btn" class="btn btn-primary">Add Address</button>
                         <button type="button" id="address-form-cancel-btn" class="btn btn-form-cancel">Cancel</button>
@@ -165,6 +168,9 @@
                     <div class="form-group">
                         <label for="card-cvv-input">CVV:</label>
                         <input type="text" id="card-cvv-input" class="form-control" placeholder="Required for new cards">
+                    </div>
+                    <div id="card-protected-note" class="protected-edit-note" style="display:none;">
+                        This is a protected card. Only limited modifications are allowed for demo purposes.
                     </div>
                     <div class="form-actions">
                         <button type="submit" id="card-form-submit-btn" class="btn btn-primary">Add Card</button>


### PR DESCRIPTION
## Summary
- highlight protected entities across the UI
- disable edit fields for protected addresses and credit cards
- warn when attempting destructive actions on protected items
- show friendly message for 403 Protected Entity errors

## Testing
- `pytest tests/test_functional.py --maxfail=1 --disable-warnings -q` *(fails: Failed to start API server)*
- `pytest tests/test_vulnerabilities.py --maxfail=1 --disable-warnings -q` *(fails: Failed to start API server)*
- `npx playwright test frontend/e2e-tests/ --timeout=60000` *(fails: ImportError: cannot import name 'url_quote')*