### PR TITLE
Add comprehensive auth endpoint tests

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,6 +23,109 @@ def test_register_and_login(test_client):
     assert "access_token" in login_response.json()
     assert login_response.json()["token_type"] == "bearer"
 
+
+def test_register_duplicate_username(test_client):
+    """Attempt registration with an existing username."""
+    username = f"dupuser_{uuid.uuid4().hex[:8]}"
+    # Initial registration should succeed
+    first = test_client.post(
+        "/api/auth/register",
+        params={"username": username, "email": f"{username}@example.com", "password": "TestPass123!"},
+    )
+    assert first.status_code == 201
+
+    # Second registration with same username should fail
+    second = test_client.post(
+        "/api/auth/register",
+        params={"username": username, "email": f"other_{username}@example.com", "password": "TestPass123!"},
+    )
+    assert second.status_code == 400
+    assert second.json()["detail"] == "Username already registered"
+
+
+def test_register_duplicate_email(test_client):
+    """Attempt registration with an existing email."""
+    email = f"dupemail_{uuid.uuid4().hex[:8]}@example.com"
+    username1 = f"user1_{uuid.uuid4().hex[:8]}"
+    username2 = f"user2_{uuid.uuid4().hex[:8]}"
+
+    response1 = test_client.post(
+        "/api/auth/register",
+        params={"username": username1, "email": email, "password": "TestPass123!"},
+    )
+    assert response1.status_code == 201
+
+    response2 = test_client.post(
+        "/api/auth/register",
+        params={"username": username2, "email": email, "password": "TestPass123!"},
+    )
+    assert response2.status_code == 400
+    assert response2.json()["detail"] == "Email already registered"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"email": "a@example.com", "password": "pwd"},
+        {"username": "user", "password": "pwd"},
+        {"username": "user", "email": "a@example.com"},
+    ],
+)
+def test_register_missing_fields(test_client, params):
+    """Registration missing required fields should return 422."""
+    response = test_client.post("/api/auth/register", params=params)
+    assert response.status_code == 422
+
+
+def test_login_existing_user_success(test_client, regular_user_credentials):
+    """Login succeeds with valid credentials for an existing user."""
+    response = test_client.post(
+        "/api/auth/login",
+        params={
+            "username": regular_user_credentials["username"],
+            "password": regular_user_credentials["password"],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data and data["token_type"] == "bearer"
+
+
+def test_login_incorrect_username(test_client):
+    """Login with a non-existent username should return 401."""
+    response = test_client.post(
+        "/api/auth/login",
+        params={"username": "unknown_user", "password": "SomePass123!"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Incorrect username or password"
+
+
+def test_login_incorrect_password(test_client, regular_user_credentials):
+    """Login with incorrect password should return 401."""
+    response = test_client.post(
+        "/api/auth/login",
+        params={
+            "username": regular_user_credentials["username"],
+            "password": "WrongPass!",
+        },
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Incorrect username or password"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"password": "pwd"},
+        {"username": "user"},
+    ],
+)
+def test_login_missing_fields(test_client, params):
+    """Login missing required fields should return 422."""
+    response = test_client.post("/api/auth/login", params=params)
+    assert response.status_code == 422
+
 # Test product listing functionality
 def test_list_products(test_client):
     """Test retrieving the list of products."""
@@ -223,3 +326,226 @@ def test_product_search(test_client):
     if len(specific_results) > 0:
         for product in specific_results:
             assert "laptop" in product["name"].lower()
+
+
+# --- User Router Tests ---
+
+def test_create_user_success(test_client):
+    """Create a new user with unique credentials."""
+    uname = f"user_{uuid.uuid4().hex[:8]}"
+    resp = test_client.post(
+        "/api/users",
+        params={"username": uname, "email": f"{uname}@example.com", "password": "Pass123!"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["username"] == uname
+    assert data["email"] == f"{uname}@example.com"
+    assert "user_id" in data
+
+
+def test_create_user_duplicate_username(test_client, regular_user_info):
+    """Creating a user with an existing username should fail."""
+    resp = test_client.post(
+        "/api/users",
+        params={
+            "username": regular_user_info["username"],
+            "email": f"dup_{uuid.uuid4().hex[:8]}@example.com",
+            "password": "Pass123!",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == f"Username '{regular_user_info['username']}' already registered"
+
+
+def test_create_user_duplicate_email(test_client, regular_user_info):
+    """Creating a user with an existing email should fail."""
+    resp = test_client.post(
+        "/api/users",
+        params={
+            "username": f"dup_{uuid.uuid4().hex[:8]}",
+            "email": regular_user_info["email"],
+            "password": "Pass123!",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == f"Email '{regular_user_info['email']}' already registered"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"email": "a@example.com", "password": "pwd"},
+        {"username": "user", "password": "pwd"},
+        {"username": "user", "email": "a@example.com"},
+    ],
+)
+def test_create_user_missing_fields(test_client, params):
+    """Missing required fields should return 422."""
+    resp = test_client.post("/api/users", params=params)
+    assert resp.status_code == 422
+
+
+def test_create_user_invalid_email(test_client):
+    """Invalid email format should return 422."""
+    resp = test_client.post(
+        "/api/users",
+        params={"username": "bademail", "email": "not-an-email", "password": "x"},
+    )
+    assert resp.status_code == 422
+
+
+def test_list_users_requires_auth(test_client):
+    """Listing users without auth should fail."""
+    resp = test_client.get("/api/users")
+    assert resp.status_code == 401
+
+
+def test_list_users_authenticated(test_client, regular_auth_headers):
+    """Authenticated user can list all users."""
+    resp = test_client.get("/api/users", headers=regular_auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+def test_get_user_no_auth_required(test_client, regular_user_info):
+    """Retrieving a user does not require authentication."""
+    user_id = regular_user_info["user_id"]
+    resp = test_client.get(f"/api/users/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == user_id
+
+
+def test_get_user_not_found(test_client):
+    resp = test_client.get(f"/api/users/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_get_user_invalid_uuid(test_client):
+    resp = test_client.get("/api/users/not-a-uuid")
+    assert resp.status_code == 422
+
+
+def test_update_non_protected_user(test_client):
+    """Update username, email and is_admin on a newly created user."""
+    base = f"edit_{uuid.uuid4().hex[:8]}"
+    create_resp = test_client.post(
+        "/api/users",
+        params={"username": base, "email": f"{base}@example.com", "password": "Pass123!"},
+    )
+    assert create_resp.status_code == 201
+    user_id = create_resp.json()["user_id"]
+
+    new_name = base + "_upd"
+    new_email = f"{new_name}@example.com"
+    resp = test_client.put(
+        f"/api/users/{user_id}",
+        params={"username": new_name, "email": new_email, "is_admin": "true"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == new_name
+    assert data["email"] == new_email
+    assert data["is_admin"] is True
+
+
+def test_update_protected_user_username_forbidden(test_client, test_data):
+    """Changing username of a protected user is forbidden."""
+    alice = next(u for u in test_data["users"] if u["username"] == "AliceSmith")
+    resp = test_client.put(
+        f"/api/users/{alice['user_id']}", params={"username": "newalice"}
+    )
+    assert resp.status_code == 403
+    expected = (
+        f"User '{alice['username']}' is protected. "
+        "Username and email cannot be changed. Other fields might be modifiable for demo purposes."
+    )
+    assert resp.json()["detail"] == expected
+
+
+def test_update_protected_user_is_admin_allowed(test_client, test_data):
+    """is_admin can be changed on a protected user."""
+    alice = next(u for u in test_data["users"] if u["username"] == "AliceSmith")
+    resp = test_client.put(
+        f"/api/users/{alice['user_id']}", params={"is_admin": "true"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_admin"] is True
+
+
+def test_update_user_duplicate_username(test_client, test_data):
+    grace = next(u for u in test_data["users"] if u["username"] == "GraceWilson")
+    henry = next(u for u in test_data["users"] if u["username"] == "HenryMoore")
+    resp = test_client.put(
+        f"/api/users/{henry['user_id']}", params={"username": grace["username"]}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == f"Username '{grace['username']}' already in use."
+
+
+def test_update_user_duplicate_email(test_client, test_data):
+    grace = next(u for u in test_data["users"] if u["username"] == "GraceWilson")
+    henry = next(u for u in test_data["users"] if u["username"] == "HenryMoore")
+    resp = test_client.put(
+        f"/api/users/{henry['user_id']}", params={"email": grace["email"]}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == f"Email '{grace['email']}' already in use."
+
+
+def test_update_user_no_data(test_client, test_data):
+    henry = next(u for u in test_data["users"] if u["username"] == "HenryMoore")
+    resp = test_client.put(f"/api/users/{henry['user_id']}")
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "No update data provided"
+
+
+def test_update_user_not_found(test_client):
+    resp = test_client.put(
+        f"/api/users/{uuid.uuid4()}", params={"username": "nouser"}
+    )
+    assert resp.status_code == 404
+
+
+def test_update_user_invalid_uuid(test_client):
+    resp = test_client.put("/api/users/not-a-uuid", params={"username": "x"})
+    assert resp.status_code == 422
+
+
+def test_delete_protected_user_forbidden(test_client, test_data):
+    alice = next(u for u in test_data["users"] if u["username"] == "AliceSmith")
+    resp = test_client.delete(f"/api/users/{alice['user_id']}")
+    assert resp.status_code == 403
+    expected = (
+        f"User '{alice['username']}' is protected for demo purposes and cannot be deleted. "
+        "Please try with a non-protected user or one you created."
+    )
+    assert resp.json()["detail"] == expected
+
+
+def test_delete_non_protected_user_success(test_client):
+    uname = f"del_{uuid.uuid4().hex[:8]}"
+    create_resp = test_client.post(
+        "/api/users",
+        params={"username": uname, "email": f"{uname}@example.com", "password": "Pass123!"},
+    )
+    assert create_resp.status_code == 201
+    user_id = create_resp.json()["user_id"]
+
+    delete_resp = test_client.delete(f"/api/users/{user_id}")
+    assert delete_resp.status_code == 204
+
+    get_resp = test_client.get(f"/api/users/{user_id}")
+    assert get_resp.status_code == 404
+
+
+def test_delete_user_not_found(test_client):
+    resp = test_client.delete(f"/api/users/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_delete_user_invalid_uuid(test_client):
+    resp = test_client.delete("/api/users/not-a-uuid")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- extend functional auth tests for register and login
- cover duplicate username/email, missing fields, bad credentials
- verify login for existing user and error responses
- add thorough user endpoint tests and handle invalid email

## Testing
- `pytest tests/test_functional.py -k "auth or register or login" -v`
- `pytest tests/test_functional.py -k "user" -v`
