### PR TITLE
Stabilize homepage e2e tests

### DIFF
--- a/frontend/e2e-tests/homepage.spec.ts
+++ b/frontend/e2e-tests/homepage.spec.ts
@@ -2,173 +2,105 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Homepage and Product Listing', () => {
   test('should load the homepage with header, search bar, and products', async ({ page }) => {
-    // Visit the home page
     await page.goto('/');
-    
-    // Check that the page title contains relevant text (more flexible)
-    await expect(page).toHaveTitle(/Radware|E-Commerce/, { timeout: 10000 });
-    
-    // Check for hero section elements - allow for different structures
-    const mainSection = page.locator('main');
-    await expect(mainSection).toBeVisible();
-    
-    // Verify main heading exists without being specific about the container class
-    await expect(page.locator('h1')).toBeVisible();
-    
-    // Verify the search form exists - fix the first() call
-    await expect(page.locator('input[type="text"], #search-term')).toBeVisible();
-    await expect(page.locator('button:has-text("Search"), .search-button')).toBeVisible();
-    
-    // Wait for product loading to complete - following the pattern from index.html and main.js
-    // Initially expect the loading indicator to be visible
-    try {
-      await expect(page.locator('div#loading-indicator')).toBeVisible({ timeout: 3000 });
-    } catch (e) {
-      console.log('Loading indicator was not visible initially or loaded too quickly');
-    }
-    
-    // Wait for loading indicator to be hidden
-    await page.waitForSelector('div#loading-indicator', { 
-      state: 'hidden',
-      timeout: 5000 
-    }).catch(() => console.log('Loading indicator did not hide or was not present'));
-    
-    // Expect products container to be visible
-    await expect(page.locator('div#products-container')).toBeVisible({ timeout: 5000 });
-    
-    // Verify products are visible with proper selectors from index.html and main.js
-    const productCards = page.locator('article.product-card');
-    await expect(productCards).toBeVisible({ timeout: 10000 });
-    
-    // Check product card structure with specific selectors
-    const firstProductCard = page.locator('article.product-card').first();
-    await expect(firstProductCard.locator('img.product-image')).toBeVisible();
-    await expect(firstProductCard.locator('h3.product-title')).toBeVisible();
-    await expect(firstProductCard.locator('button.add-to-cart-btn')).toBeVisible();
+
+    await expect(page).toHaveTitle(/RVA eCommerce|Radware/i, { timeout: 10000 });
+
+    await expect(page.locator('main h1')).toBeVisible();
+    await expect(page.locator('#search-term')).toBeVisible();
+    await expect(page.locator('form#search-form button[type="submit"]')).toBeVisible();
+
+    const loading = page.locator('#loading-indicator');
+    await expect(loading).toBeHidden({ timeout: 15000 });
+
+    const products = page.locator('#products-container .product-card');
+    await expect(products.first()).toBeVisible({ timeout: 10000 });
+    expect(await products.count()).toBeGreaterThan(0);
+
+    const firstCard = products.first();
+    await expect(firstCard.locator('img.product-image')).toBeVisible();
+    await expect(firstCard.locator('h3.product-title')).toBeVisible();
+    await expect(firstCard.locator('p.price')).toBeVisible();
+    await expect(firstCard.locator('button.add-to-cart-btn')).toBeVisible();
   });
   
   test('should be able to search for products', async ({ page }) => {
     await page.goto('/');
-    
-    // Wait for products to load - using consistent pattern from index.html and main.js
-    // Wait for loading indicator to be hidden
-    await page.waitForSelector('div#loading-indicator', { 
-      state: 'hidden',
-      timeout: 5000 
-    }).catch(() => console.log('Loading indicator did not hide or was not present'));
-    
-    // Wait for products container to be visible with products
-    await expect(page.locator('div#products-container')).toBeVisible({ timeout: 5000 });
-    
-    // Verify initial product grid is visible - fix the first() call
-    const productCards = page.locator('.product-card, article');
-    await expect(productCards).toBeVisible();
-    
-    // Count initial products
-    const initialProductCount = await page.locator('.product-card, article').count();
-    
-    // Search for a specific product
-    await page.fill('input[type="text"], #search-term', 'Laptop');
-    await page.click('button:has-text("Search"), .search-button');
-    
-    // Wait for search results to load
-    await page.waitForTimeout(1000);
-    
-    // Check the search results contain fewer products (filtered)
-    const filteredProductCount = await page.locator('.product-card, article').count();
-    expect(filteredProductCount).toBeLessThanOrEqual(initialProductCount);
-    
-    // Check at least one product with "Laptop" is visible
-    await expect(page.locator('h3, .product-title')).toContainText(/Laptop/i, { timeout: 10000 });
+
+    const loading = page.locator('#loading-indicator');
+    await expect(loading).toBeHidden({ timeout: 15000 });
+
+    const productLocator = page.locator('#products-container .product-card');
+    await expect(productLocator.first()).toBeVisible({ timeout: 10000 });
+    const initialCount = await productLocator.count();
+
+    await page.fill('#search-term', 'Laptop');
+    const [response] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/products/search') && r.status() === 200),
+      page.locator('form#search-form button[type="submit"]').click()
+    ]);
+    expect(response.ok()).toBeTruthy();
+
+    await expect(productLocator.first()).toBeVisible({ timeout: 10000 });
+    const filteredCount = await productLocator.count();
+    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+    await expect(productLocator.locator('h3.product-title')).toContainText(/Laptop/i);
+    await expect(page.locator('#search-info')).toBeVisible();
   });
   
   test('should add a product to cart and show feedback', async ({ page }) => {
     await page.goto('/');
-    
-    // Wait for products to load
-    await page.waitForSelector('.product-card, article', { timeout: 10000 });
-    
-    // Store initial cart count
+
+    const loading = page.locator('#loading-indicator');
+    await expect(loading).toBeHidden({ timeout: 15000 });
+
     const cartBadge = page.locator('#cart-item-count');
-    const initialCart = await cartBadge.textContent() || '0';
-    const initialCount = parseInt(initialCart.match(/\d+/)?.[0] || '0', 10);
-    
-    // Get product name for verification
-    const firstProduct = page.locator('.product-card, article').first();
-    const productName = await firstProduct.locator('h3, .product-title').textContent();
-    
-    // Add product to cart
-    await firstProduct.locator('button, .add-to-cart-btn').click();
-    
-    // Wait for cart update
-    await page.waitForTimeout(1000);
-    
-    // Verify cart count increased
-    const updatedCart = await cartBadge.textContent() || '0';
-    const updatedCount = parseInt(updatedCart.match(/\d+/)?.[0] || '0', 10);
-    expect(updatedCount).toBeGreaterThan(initialCount);
-    
-    // Check for success notification - try different possible elements
-    try {
-      // First try toast notification
-      const toastVisible = await page.locator('#toast-notification, .toast-notification').isVisible();
-      
-      if (toastVisible) {
-        // Success!
-        expect(toastVisible).toBeTruthy();
-      } else {
-        // Try global message
-        const globalMessage = await page.locator('#global-messages-container .global-message.success-message, #global-messages-container .global-message.info-message').isVisible();
-        expect(globalMessage).toBeTruthy();
-      }
-    } catch (e) {
-      // If neither notification element is found, check if cart count changed as verification
-      expect(updatedCount).toBeGreaterThan(initialCount);
-    }
+    const startCount = parseInt((await cartBadge.innerText()) || '0', 10);
+
+    const firstProduct = page.locator('#products-container .product-card').first();
+    await firstProduct.locator('button.add-to-cart-btn').click();
+
+    const successMessage = page.locator('#global-message-container .global-message.success-message');
+    await expect(successMessage).toContainText('Added', { timeout: 10000 });
+
+    const endCount = parseInt((await cartBadge.innerText()) || '0', 10);
+    expect(endCount).toBeGreaterThan(startCount);
   });
   
   test('should demonstrate potential injection vulnerability in search', async ({ page }) => {
     await page.goto('/');
-    
-    // Wait for products to load
-    await page.waitForSelector('.product-card, article', { timeout: 10000 });
-    
-    // Enter an SQL injection query
-    await page.fill('input[type="text"], #search-term', "' OR 1=1 --");
-    await page.click('button:has-text("Search"), .search-button');
-    
-    // Wait for either search results or error message
-    await page.waitForTimeout(1000);
-    
-    // Verify injection note is displayed
-    await expect(page.locator('#search-info, .note')).toBeVisible({ timeout: 10000 });
+
+    const loading = page.locator('#loading-indicator');
+    await expect(loading).toBeHidden({ timeout: 15000 });
+
+    await page.fill('#search-term', "' OR 1=1 --");
+    await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/products/search') && r.status() === 200),
+      page.locator('form#search-form button[type="submit"]').click()
+    ]);
+
+    await expect(page.locator('#search-info')).toBeVisible();
   });
   
   test('should have responsive design for different screen sizes', async ({ page }) => {
-    // Set viewport to desktop size
     await page.setViewportSize({ width: 1200, height: 800 });
     await page.goto('/');
-    
-    // Wait for products to load
-    await page.waitForSelector('.product-card, article', { timeout: 10000 });
-    
-    // Get grid template for desktop
+
+    const loading = page.locator('#loading-indicator');
+    await expect(loading).toBeHidden({ timeout: 15000 });
+
     const desktopGridStyle = await page.evaluate(() => {
-      const container = document.querySelector('.product-grid, #products-container');
+      const container = document.querySelector('#products-container');
       return container ? window.getComputedStyle(container).gridTemplateColumns : '';
     });
-    
-    // Set viewport to mobile size
+
     await page.setViewportSize({ width: 480, height: 800 });
-    
-    // Get grid template for mobile
+
     const mobileGridStyle = await page.evaluate(() => {
-      const container = document.querySelector('.product-grid, #products-container');
+      const container = document.querySelector('#products-container');
       return container ? window.getComputedStyle(container).gridTemplateColumns : '';
     });
-    
-    // Verify the grid templates are different for responsive design
-    // Instead of checking for specific CSS, just verify they're different
+
     expect(desktopGridStyle).not.toBe(mobileGridStyle);
   });
 });


### PR DESCRIPTION
## Summary
- improve selectors and explicit waits in homepage Playwright tests
- check search results and cart updates reliably
- remove flaky timeouts and verify responsive grid

## Testing
- `CI=1 npx playwright test frontend/e2e-tests/homepage.spec.ts --reporter=line`