### PR TITLE
Update E2E tests for new default logic

### DIFF
--- a/frontend/e2e-tests/admin-ui.spec.ts
+++ b/frontend/e2e-tests/admin-ui.spec.ts
@@ -67,8 +67,11 @@ test.describe('Admin Page UI Demos', () => {
       page.locator('#delete-user-form button[type="submit"]').click()
     ]);
     expect(resp.status()).toBe(403);
-    const warn = page.locator('#global-message-container .global-message.warning-message');
-    await expect(warn).toContainText('Action Blocked');
+    const warn = page
+      .locator('#global-message-container .global-message.warning-message')
+      .filter({ hasText: 'Action Blocked' })
+      .first();
+    await expect(warn).toContainText(/Action Blocked/);
     await expect(warn).toContainText(/protected for demo purposes/i);
   });
 });

--- a/frontend/e2e-tests/checkout.spec.ts
+++ b/frontend/e2e-tests/checkout.spec.ts
@@ -97,13 +97,19 @@ test.describe('Checkout Process', () => {
     await page.goto('/');
     await expect(page.locator('#loading-indicator')).toBeHidden({ timeout: 15000 });
     const laptop = page.locator('article.product-card', { hasText: 'Laptop Pro 15' });
-    await laptop.locator('button.add-to-cart-btn').click();
-    await expect(page.locator('#global-message-container .global-message.success-message')).toBeVisible({ timeout: 10000 });
+      await laptop.locator('button.add-to-cart-btn').click();
+      await expect(
+        page.locator('#global-message-container .global-message.success-message').first()
+      ).toBeVisible({ timeout: 10000 });
     const mouse = page.locator('article.product-card', { hasText: 'Wireless Mouse' });
-    await mouse.locator('button.add-to-cart-btn').click();
-    await expect(page.locator('#global-message-container .global-message.success-message')).toBeVisible();
-    await mouse.locator('button.add-to-cart-btn').click();
-    await expect(page.locator('#global-message-container .global-message.success-message')).toBeVisible();
+      await mouse.locator('button.add-to-cart-btn').click();
+      await expect(
+        page.locator('#global-message-container .global-message.success-message').first()
+      ).toBeVisible();
+      await mouse.locator('button.add-to-cart-btn').click();
+      await expect(
+        page.locator('#global-message-container .global-message.success-message').first()
+      ).toBeVisible();
     await page.goto('/checkout');
     await page.waitForSelector('#address-id option[value]:not([value=""])', { state: 'attached', timeout: 30000 });
     await page.waitForSelector('#credit-card-id option[value]:not([value=""])', { state: 'attached', timeout: 30000 });


### PR DESCRIPTION
## Summary
- adjust admin UI test warning selector
- fix checkout test success message expectations

## Testing
- `pytest tests/ -v`
- `npx playwright test frontend/e2e-tests/profile-address-management.spec.ts`
