### PR TITLE
Add enhanced order info tests and support

### DIFF
--- a/app/routers/order_router.py
+++ b/app/routers/order_router.py
@@ -150,6 +150,12 @@ async def create_user_order(
     # Prepare response model
     order_response = Order.model_validate(new_order_db)
     order_response.items = [OrderItem.model_validate(item) for item in created_order_items_db]
+    card = next(
+        (cc for cc in db.db["credit_cards"] if cc.card_id == new_order_db.credit_card_id),
+        None,
+    )
+    if card:
+        order_response.credit_card_last_four = card.card_last_four
     
     print(f"Order {new_order_db.order_id} created successfully for user {user_id} with total {new_order_db.total_amount}.")
     return order_response

--- a/frontend/e2e-tests/orders-ui.spec.ts
+++ b/frontend/e2e-tests/orders-ui.spec.ts
@@ -76,6 +76,25 @@ test.describe('Orders Page UI', () => {
       await expect(rows.first()).toBeVisible({ timeout: 15000 });
       expect(await rows.count()).toBeGreaterThan(1);
       await expect(page.locator('#current-viewing')).toBeHidden();
+
+      // Verify headers for enhanced columns
+      await expect(
+        page.locator('#orders-container table th').filter({ hasText: 'Date & Time' })
+      ).toBeVisible();
+      await expect(
+        page.locator('#orders-container table th').filter({ hasText: 'Card Used' })
+      ).toBeVisible();
+
+      // Verify first row displays date/time and card info
+      const firstRow = rows.first();
+      const dateTimeCell = firstRow.locator('td').nth(1);
+      await expect(dateTimeCell).not.toBeEmpty();
+      const dtText = await dateTimeCell.textContent();
+      expect(dtText || '').toContain('/');
+      expect(dtText || '').toContain(':');
+
+      const cardCell = firstRow.locator('td').nth(4);
+      await expect(cardCell).toHaveText(/\u2022{4} \d{4}/);
     });
   });
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -606,6 +606,15 @@ def test_order_creation_and_retrieval(
     assert new_order["items"][0]["product_id"] == product["product_id"]
     assert new_order["items"][0]["quantity"] == 1
 
+    # Verify enhanced info fields on creation response
+    assert isinstance(new_order["created_at"], str)
+    assert "T" in new_order["created_at"]
+    from datetime import datetime
+
+    datetime.fromisoformat(new_order["created_at"])
+    expected_last_four = user_card["card_number_plain"][-4:]
+    assert new_order["credit_card_last_four"] == expected_last_four
+
     # Retrieve the order
     get_response = test_client.get(
         f"/api/users/{user_id}/orders/{new_order['order_id']}",
@@ -614,6 +623,10 @@ def test_order_creation_and_retrieval(
     assert get_response.status_code == 200
     retrieved_order = get_response.json()
     assert retrieved_order["order_id"] == new_order["order_id"]
+    assert isinstance(retrieved_order["created_at"], str)
+    assert "T" in retrieved_order["created_at"]
+    datetime.fromisoformat(retrieved_order["created_at"])
+    assert retrieved_order["credit_card_last_four"] == expected_last_four
 
     # List all orders
     list_response = test_client.get(
@@ -622,6 +635,11 @@ def test_order_creation_and_retrieval(
     assert list_response.status_code == 200
     orders = list_response.json()
     assert any(order["order_id"] == new_order["order_id"] for order in orders)
+    target_order = next(o for o in orders if o["order_id"] == new_order["order_id"])
+    assert isinstance(target_order["created_at"], str)
+    assert "T" in target_order["created_at"]
+    datetime.fromisoformat(target_order["created_at"])
+    assert target_order["credit_card_last_four"] == expected_last_four
 
 
 # Test product search functionality

--- a/tests/test_vulnerabilities.py
+++ b/tests/test_vulnerabilities.py
@@ -91,6 +91,12 @@ def test_bola_user_orders_access(
     # The response is a list of orders, which might be empty if the user hasn't placed any
     for order in orders:
         assert order["user_id"] == victim_user_id
+        assert isinstance(order["created_at"], str)
+        assert "T" in order["created_at"]
+        from datetime import datetime
+
+        datetime.fromisoformat(order["created_at"])
+        assert "credit_card_last_four" in order
 
 
 def test_bola_create_address_for_another_user(
@@ -151,6 +157,13 @@ def test_bola_cross_user_order_creation(
     assert new_order["user_id"] == victim_user_id
     assert new_order["address_id"] == victim_address["address_id"]
     assert new_order["credit_card_id"] == victim_card["card_id"]
+    assert isinstance(new_order["created_at"], str)
+    assert "T" in new_order["created_at"]
+    from datetime import datetime
+
+    datetime.fromisoformat(new_order["created_at"])
+    expected_last_four = victim_card["card_number_plain"][-4:]
+    assert new_order["credit_card_last_four"] == expected_last_four
 
 
 def test_bola_using_another_users_address_for_order(
@@ -180,6 +193,13 @@ def test_bola_using_another_users_address_for_order(
     new_order = response.json()
     assert new_order["user_id"] == user_id
     assert new_order["address_id"] == victim_address["address_id"]
+    assert isinstance(new_order["created_at"], str)
+    assert "T" in new_order["created_at"]
+    from datetime import datetime
+
+    datetime.fromisoformat(new_order["created_at"])
+    expected_last_four = user_card["card_number_plain"][-4:]
+    assert new_order["credit_card_last_four"] == expected_last_four
 
 
 def test_bola_using_another_users_card_for_order(
@@ -204,6 +224,13 @@ def test_bola_using_another_users_card_for_order(
     new_order = response.json()
     assert new_order["user_id"] == user_id
     assert new_order["credit_card_id"] == victim_card["card_id"]
+    assert isinstance(new_order["created_at"], str)
+    assert "T" in new_order["created_at"]
+    from datetime import datetime
+
+    datetime.fromisoformat(new_order["created_at"])
+    expected_last_four = victim_card["card_number_plain"][-4:]
+    assert new_order["credit_card_last_four"] == expected_last_four
 
 
 # --- Additional BOLA address & credit card modification tests ---


### PR DESCRIPTION
## Summary
- extend Orders API to include `credit_card_last_four` on order creation
- check enhanced fields in functional and vulnerability tests
- expand Orders UI test to assert date, time, and card number display

## Testing
- `pytest tests/test_functional.py::test_order_creation_and_retrieval -v`
- `pytest tests/test_vulnerabilities.py::test_bola_user_orders_access -v`
- `pytest tests/test_vulnerabilities.py::test_bola_cross_user_order_creation -v`
- `pytest tests/test_vulnerabilities.py::test_bola_using_another_users_address_for_order -v`
- `pytest tests/test_vulnerabilities.py::test_bola_using_another_users_card_for_order -v`
- `npx playwright test frontend/e2e-tests/orders-ui.spec.ts`