### PR TITLE
Add credit_card_last_four to Order schema in JSON spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1841,6 +1841,12 @@
               "$ref": "#/components/schemas/OrderItem"
             },
             "default": []
+          },
+          "credit_card_last_four": {
+            "type": "string",
+            "nullable": true,
+            "description": "Last four digits of the credit card used for the order, if available.",
+            "readOnly": true
           }
         }
       },


### PR DESCRIPTION
## Summary
- include `credit_card_last_four` field in the `Order` schema of `openapi.json`

The YAML spec remains untouched and should be manually synchronized.

## Testing
- `pytest tests/test_functional.py::test_order_creation_and_retrieval -v`