### PR TITLE
Switch delete endpoints to 200

### DIFF
--- a/app/routers/product_router.py
+++ b/app/routers/product_router.py
@@ -156,7 +156,6 @@ async def update_existing_product(
             ),
         )
 
-
     # Use ProductUpdate model to get clean update data
     update_data = ProductUpdate(
         name=name,
@@ -187,7 +186,10 @@ async def update_existing_product(
 
 # BFLA Target: No admin check initially.
 @router.delete(
-    "/products/{product_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Products"]
+    "/products/{product_id}",
+    status_code=status.HTTP_200_OK,
+    tags=["Products"],
+    response_model=dict,
 )
 async def delete_existing_product(
     product_id: UUID,
@@ -218,7 +220,6 @@ async def delete_existing_product(
             ),
         )
 
-
     print(
         f"Deleting product {product_id}. Intended BFLA: No admin check performed."
     )  # Logging for demo
@@ -226,7 +227,7 @@ async def delete_existing_product(
     # Also remove associated stock
     db.db["stock"] = [s for s in db.db["stock"] if s.product_id != product_id]
     # Consider implications for orders with this product (e.g., mark as unavailable, don't delete from historical orders)
-    return
+    return {"message": "Product deleted successfully"}
 
 
 @router.get("/products/{product_id}/stock", response_model=Stock, tags=["Stock"])
@@ -292,7 +293,6 @@ async def update_product_stock_quantity(
                 ),
             )
 
-   
     if not stock_to_update:
         # If product exists but stock record doesn't, create it (could happen if product was added without stock init)
         print(f"Stock record for product {product_id} not found. Creating one.")

--- a/app/routers/user_profile_router.py
+++ b/app/routers/user_profile_router.py
@@ -206,7 +206,9 @@ async def update_user_address(
     return Address.model_validate(address_to_update)
 
 
-@router.delete("/addresses/{address_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/addresses/{address_id}", status_code=status.HTTP_200_OK, response_model=dict
+)
 async def delete_user_address(
     user_id: UUID,  # User ID from path
     address_id: UUID,
@@ -272,7 +274,8 @@ async def delete_user_address(
                 print(
                     f"Address {remaining_user_addresses[0].address_id} (item.is_protected) made default for user {user_id} after deleting previous default."
                 )
-    return
+
+    return {"message": "Address deleted successfully"}
 
 
 # --- Credit Card Endpoints (BOLA Targets - for demonstration) ---
@@ -488,7 +491,9 @@ async def update_user_credit_card(
     return CreditCard.model_validate(card_to_update)
 
 
-@router.delete("/credit-cards/{card_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/credit-cards/{card_id}", status_code=status.HTTP_200_OK, response_model=dict
+)
 async def delete_user_credit_card(
     user_id: UUID,  # User ID from path
     card_id: UUID,
@@ -552,4 +557,5 @@ async def delete_user_credit_card(
                 print(
                     f"Card {remaining_user_cards[0].card_id} (item.is_protected) made default for user {user_id} after deleting previous default."
                 )
-    return
+
+    return {"message": "Credit card deleted successfully"}

--- a/app/routers/user_router.py
+++ b/app/routers/user_router.py
@@ -197,7 +197,10 @@ async def update_user(
 
 # BFLA Target: Initially, no admin check for deleting users.
 @router.delete(
-    "/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Users"]
+    "/users/{user_id}",
+    status_code=status.HTTP_200_OK,
+    tags=["Users"],
+    response_model=dict,
 )
 async def delete_user(
     user_id: UUID,
@@ -240,7 +243,7 @@ async def delete_user(
     ]
     # Orders might be kept for historical reasons or marked inactive.
 
-    return
+    return {"message": "User deleted successfully"}
 
 
 @router.get("/users", response_model=List[User], tags=["Users"])
@@ -504,8 +507,9 @@ async def update_user_credit_card(
 
 @router.delete(
     "/users/{user_id}/credit-cards/{card_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_200_OK,
     tags=["Credit Cards"],
+    response_model=dict,
 )
 async def delete_user_credit_card(user_id: UUID, card_id: UUID):
     """Delete a specific credit card for a given user."""
@@ -568,4 +572,4 @@ async def delete_user_credit_card(user_id: UUID, card_id: UUID):
     print(
         f"Credit card {card_id} for user {user_id} deleted. Intended BOLA: No owner check performed."
     )
-    return
+    return {"message": "Credit card deleted successfully"}

--- a/openapi.json
+++ b/openapi.json
@@ -248,8 +248,21 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "User deleted successfully"
+          "200": {
+            "description": "User deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "User deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
           },
           "403": {
             "description": "Action Forbidden: The user is protected for demo purposes and cannot be deleted."
@@ -489,8 +502,21 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Product deleted successfully"
+          "200": {
+            "description": "Product deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Product deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
           },
           "403": {
             "description": "Action Forbidden: Product is protected for demo purposes and cannot be deleted."
@@ -900,8 +926,21 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Address deleted successfully"
+          "200": {
+            "description": "Address deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Address deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
@@ -1218,8 +1257,21 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Credit card deleted successfully"
+          "200": {
+            "description": "Credit card deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Credit card deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
           },
           "403": {
             "description": "Action Forbidden: Credit Card is protected and cannot be deleted."

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -230,7 +230,9 @@ def test_address_management(test_client, regular_auth_headers, regular_user_info
         f"/api/users/{user_id}/addresses/{new_address['address_id']}",
         headers=regular_auth_headers,
     )
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 200
+    delete_data = delete_response.json()
+    assert "Address deleted".lower() in delete_data.get("message", "").lower()
 
     # Verify address was deleted
     list_after_delete = test_client.get(
@@ -282,7 +284,9 @@ def test_credit_card_management(test_client, regular_auth_headers, regular_user_
         f"/api/users/{user_id}/credit-cards/{new_card['card_id']}",
         headers=regular_auth_headers,
     )
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 200
+    del_data = delete_response.json()
+    assert "credit card deleted" in del_data.get("message", "").lower()
 
 
 # --- Additional Address Endpoint Tests ---
@@ -383,7 +387,9 @@ def test_update_delete_address_non_protected(
     delete_resp = test_client.delete(
         f"/api/users/{user_id}/addresses/{addr_id}", headers=non_protected_auth_headers
     )
-    assert delete_resp.status_code == 204
+    assert delete_resp.status_code == 200
+    del_data = delete_resp.json()
+    assert "address deleted" in del_data.get("message", "").lower()
 
 
 def test_protected_address_modification_forbidden(
@@ -503,7 +509,9 @@ def test_update_delete_credit_card_non_protected(
         f"/api/users/{user_id}/credit-cards/{card_id}",
         headers=non_protected_auth_headers,
     )
-    assert delete_resp.status_code == 204
+    assert delete_resp.status_code == 200
+    del_data = delete_resp.json()
+    assert "credit card deleted" in del_data.get("message", "").lower()
 
 
 def test_protected_credit_card_modification_forbidden(
@@ -723,7 +731,9 @@ def test_create_update_delete_product_flow(test_client):
     assert up.get("internal_status") == "hidden"
 
     delete_resp = test_client.delete(f"/api/products/{pid}")
-    assert delete_resp.status_code == 204
+    assert delete_resp.status_code == 200
+    del_data = delete_resp.json()
+    assert "product deleted" in del_data.get("message", "").lower()
     get_resp = test_client.get(f"/api/products/{pid}")
     assert get_resp.status_code == 404
 
@@ -1383,7 +1393,9 @@ def test_delete_non_protected_user_success(test_client):
     )
     user_id = create.json()["user_id"]
     delete_resp = test_client.delete(f"/api/users/{user_id}")
-    assert delete_resp.status_code == 204
+    assert delete_resp.status_code == 200
+    del_data = delete_resp.json()
+    assert "user deleted" in del_data.get("message", "").lower()
     get_resp = test_client.get(f"/api/users/{user_id}")
     assert get_resp.status_code == 404
 
@@ -1399,7 +1411,9 @@ def test_delete_user_invalid_uuid(test_client):
     assert resp.status_code == 422
 
 
-def test_delete_last_address_forbidden_protected_user(test_client, test_data, regular_auth_headers):
+def test_delete_last_address_forbidden_protected_user(
+    test_client, test_data, regular_auth_headers
+):
     """Deleting the last remaining address of a protected user should fail."""
     david = next(u for u in test_data["users"] if u["username"] == "DavidBrown")
     user_id = david["user_id"]
@@ -1410,7 +1424,9 @@ def test_delete_last_address_forbidden_protected_user(test_client, test_data, re
         f"/api/users/{user_id}/addresses/{addr_ids[0]}",
         headers=regular_auth_headers,
     )
-    assert first_del.status_code == 204
+    assert first_del.status_code == 200
+    del_data = first_del.json()
+    assert "address deleted" in del_data.get("message", "").lower()
 
     # Attempt to delete last remaining address
     second_del = test_client.delete(
@@ -1426,7 +1442,9 @@ def test_delete_last_address_forbidden_protected_user(test_client, test_data, re
     db.initialize_database_from_json()
 
 
-def test_delete_last_credit_card_forbidden_protected_user(test_client, test_data, regular_auth_headers):
+def test_delete_last_credit_card_forbidden_protected_user(
+    test_client, test_data, regular_auth_headers
+):
     """Deleting the only credit card of a protected user should return 403."""
     david = next(u for u in test_data["users"] if u["username"] == "DavidBrown")
     user_id = david["user_id"]
@@ -1444,7 +1462,9 @@ def test_delete_last_credit_card_forbidden_protected_user(test_client, test_data
     db.initialize_database_from_json()
 
 
-def test_delete_default_address_auto_select_new_default(test_client, test_data, regular_auth_headers):
+def test_delete_default_address_auto_select_new_default(
+    test_client, test_data, regular_auth_headers
+):
     """Deleting a default address should promote another address to default."""
     david = next(u for u in test_data["users"] if u["username"] == "DavidBrown")
     user_id = david["user_id"]
@@ -1455,7 +1475,9 @@ def test_delete_default_address_auto_select_new_default(test_client, test_data, 
         f"/api/users/{user_id}/addresses/{default_id}",
         headers=regular_auth_headers,
     )
-    assert del_resp.status_code == 204
+    assert del_resp.status_code == 200
+    del_data = del_resp.json()
+    assert "address deleted" in del_data.get("message", "").lower()
 
     remaining = test_client.get(
         f"/api/users/{user_id}/addresses",
@@ -1470,7 +1492,9 @@ def test_delete_default_address_auto_select_new_default(test_client, test_data, 
     db.initialize_database_from_json()
 
 
-def test_delete_default_credit_card_auto_select_new_default(test_client, test_data, regular_auth_headers):
+def test_delete_default_credit_card_auto_select_new_default(
+    test_client, test_data, regular_auth_headers
+):
     """Deleting a default credit card should promote another card to default."""
     frank = next(u for u in test_data["users"] if u["username"] == "FrankMiller")
     user_id = frank["user_id"]
@@ -1481,7 +1505,9 @@ def test_delete_default_credit_card_auto_select_new_default(test_client, test_da
         f"/api/users/{user_id}/credit-cards/{default_id}",
         headers=regular_auth_headers,
     )
-    assert del_resp.status_code == 204
+    assert del_resp.status_code == 200
+    del_data = del_resp.json()
+    assert "credit card deleted" in del_data.get("message", "").lower()
 
     remaining = test_client.get(
         f"/api/users/{user_id}/credit-cards",
@@ -1496,7 +1522,9 @@ def test_delete_default_credit_card_auto_select_new_default(test_client, test_da
     db.initialize_database_from_json()
 
 
-def test_set_default_address_when_current_default_protected(test_client, regular_auth_headers, regular_user_info):
+def test_set_default_address_when_current_default_protected(
+    test_client, regular_auth_headers, regular_user_info
+):
     """Protected user can change default even if current default is protected."""
     user_id = regular_user_info["user_id"]
     old_default_id = regular_user_info["addresses"][0]["address_id"]
@@ -1532,7 +1560,9 @@ def test_set_default_address_when_current_default_protected(test_client, regular
     db.initialize_database_from_json()
 
 
-def test_set_default_address_allowed_when_current_default_not_protected(test_client, regular_auth_headers, test_data):
+def test_set_default_address_allowed_when_current_default_not_protected(
+    test_client, regular_auth_headers, test_data
+):
     """Setting default succeeds when current default is not protected."""
     david = next(u for u in test_data["users"] if u["username"] == "DavidBrown")
     user_id = david["user_id"]
@@ -1588,7 +1618,9 @@ def test_set_default_address_allowed_when_current_default_not_protected(test_cli
     db.initialize_database_from_json()
 
 
-def test_set_default_credit_card_when_current_default_protected(test_client, regular_auth_headers, regular_user_info):
+def test_set_default_credit_card_when_current_default_protected(
+    test_client, regular_auth_headers, regular_user_info
+):
     """Protected user can change default card even if current default is protected."""
     user_id = regular_user_info["user_id"]
     old_default_id = regular_user_info["credit_cards"][0]["card_id"]
@@ -1625,7 +1657,9 @@ def test_set_default_credit_card_when_current_default_protected(test_client, reg
     db.initialize_database_from_json()
 
 
-def test_set_default_credit_card_allowed_when_current_default_not_protected(test_client, regular_auth_headers, test_data):
+def test_set_default_credit_card_allowed_when_current_default_not_protected(
+    test_client, regular_auth_headers, test_data
+):
     """Setting new default succeeds when existing default is not protected."""
     frank = next(u for u in test_data["users"] if u["username"] == "FrankMiller")
     user_id = frank["user_id"]
@@ -1681,4 +1715,3 @@ def test_set_default_credit_card_allowed_when_current_default_not_protected(test
     from app import db
 
     db.initialize_database_from_json()
-

--- a/tests/test_vulnerabilities.py
+++ b/tests/test_vulnerabilities.py
@@ -320,7 +320,9 @@ def test_bola_delete_address_for_another_user(
         f"/api/users/{victim_user_id}/addresses/{addr_id}",
         headers=regular_auth_headers,
     )
-    assert resp.status_code == 204
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "address deleted" in data.get("message", "").lower()
 
 
 def test_bola_update_protected_credit_card_forbidden(
@@ -370,7 +372,9 @@ def test_bola_delete_protected_credit_card_forbidden(
         f"/api/users/{victim_user_id}/credit-cards/{card_id}",
         headers=regular_auth_headers,
     )
-    assert resp.status_code == 204
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "credit card deleted" in data.get("message", "").lower()
 
 
 def test_bola_delete_credit_card_for_another_user(
@@ -394,7 +398,9 @@ def test_bola_delete_credit_card_for_another_user(
         f"/api/users/{victim_user_id}/credit-cards/{card_id}",
         headers=regular_auth_headers,
     )
-    assert resp.status_code == 204
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "credit card deleted" in data.get("message", "").lower()
 
 
 # Test for BFLA (Broken Function Level Authorization) vulnerabilities
@@ -440,7 +446,9 @@ def test_bfla_product_deletion_by_regular_user(test_client, regular_auth_headers
     )
 
     # Vulnerability test passes if the product is deleted
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 200
+    del_data = delete_response.json()
+    assert "product deleted" in del_data.get("message", "").lower()
 
     # Verify deletion
     get_response = test_client.get(f"/api/products/{product_id}")
@@ -497,7 +505,9 @@ def test_bfla_user_deletion_by_regular_user(test_client, regular_auth_headers):
     )
 
     # Vulnerability test passes if the user is deleted
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 200
+    del_data = delete_response.json()
+    assert "user deleted" in del_data.get("message", "").lower()
 
     # Verify deletion
     get_response = test_client.get(


### PR DESCRIPTION
## Summary
- return JSON body for delete operations instead of 204
- update tests to expect HTTP 200 with success messages
- adjust OpenAPI spec accordingly

## Testing
- `pytest tests/ -v`