### PR TITLE
Update Playwright tests for 200 delete responses

### DIFF
--- a/frontend/e2e-tests/admin-ui.spec.ts
+++ b/frontend/e2e-tests/admin-ui.spec.ts
@@ -55,10 +55,12 @@ test.describe('Admin Page UI Demos', () => {
     await page.goto('/admin');
     await page.fill('#delete-user-id', graceId);
     page.once('dialog', d => d.accept());
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes(`/api/users/${graceId}`) && r.request().method() === 'DELETE' && r.status() === 204),
+    const [delResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes(`/api/users/${graceId}`) && r.request().method() === 'DELETE' && r.status() === 200),
       page.locator('#delete-user-form button[type="submit"]').click()
     ]);
+    const delBody = await delResp.json();
+    expect(delBody.message).toMatch(/user deleted/i);
     await expect(page.locator('#global-message-container .global-message.success-message')).toContainText(/User .* deleted/i);
     await page.fill('#delete-user-id', bobId);
     page.once('dialog', d => d.accept());

--- a/frontend/e2e-tests/profile-address-management.spec.ts
+++ b/frontend/e2e-tests/profile-address-management.spec.ts
@@ -87,10 +87,12 @@ test.describe.serial('Profile Page - Address Management', () => {
     await page.unroute('**/addresses/**');
 
     page.once('dialog', d => d.accept());
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/addresses/') && r.request().method() === 'DELETE' && r.status() === 204, { timeout: 20000 }),
+    const [delResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/addresses/') && r.request().method() === 'DELETE' && r.status() === 200, { timeout: 20000 }),
       updatedCard.locator('.delete-address-btn').click()
     ]);
+    const delBody = await delResp.json();
+    expect(delBody.message).toMatch(/address deleted/i);
     await expect(successMsg.filter({ hasText: /Address deleted successfully/i })).toBeVisible({ timeout: 15000 });
     await expect(page.locator('#address-list-container .address-card', { hasText: 'Updated Test Street' })).toHaveCount(0);
   });
@@ -128,10 +130,12 @@ test.describe.serial('Profile Page - Address Management', () => {
     await expect(page.locator('.address-card', { hasText: '123 Oak Street' }).locator('.default-badge')).toHaveCount(0);
 
     page.once('dialog', d => d.accept());
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes(`/addresses/${addrId}`) && r.request().method() === 'DELETE' && r.status() === 204, { timeout: 20000 }),
+    const [delResp2] = await Promise.all([
+      page.waitForResponse(r => r.url().includes(`/addresses/${addrId}`) && r.request().method() === 'DELETE' && r.status() === 200, { timeout: 20000 }),
       newCard.locator('.delete-address-btn').click()
     ]);
+    const delBody2 = await delResp2.json();
+    expect(delBody2.message).toMatch(/address deleted/i);
   });
 
   test('should allow editing a protected address via UI', async ({ page }) => {
@@ -162,10 +166,12 @@ test.describe.serial('Profile Page - Address Management', () => {
   test('should allow deleting a protected address when another address exists', async ({ page }) => {
     const protectedCard = page.locator('.address-card', { hasText: '123 Oak Street' });
     page.once('dialog', dialog => dialog.accept());
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/addresses/') && r.request().method() === 'DELETE' && r.status() === 204, { timeout: 20000 }),
+    const [delResp3] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/addresses/') && r.request().method() === 'DELETE' && r.status() === 200, { timeout: 20000 }),
       protectedCard.locator('.delete-address-btn').click()
     ]);
+    const delBody3 = await delResp3.json();
+    expect(delBody3.message).toMatch(/address deleted/i);
     const success = page.locator('#global-message-container .global-message.success-message').filter({ hasText: 'Address deleted successfully' });
     await expect(success).toBeVisible({ timeout: 15000 });
     await expect(protectedCard).toHaveCount(0);
@@ -208,10 +214,12 @@ test.describe.serial('Profile Page - Address Management', () => {
     await expect(page.locator('.credit-card-card', { hasText: 'Alice Smith' }).locator('.default-badge')).toHaveCount(0);
 
     page.once('dialog', d => d.accept());
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes(`/credit-cards/${cardId}`) && r.request().method() === 'DELETE' && r.status() === 204, { timeout: 20000 }),
+    const [delRespCard] = await Promise.all([
+      page.waitForResponse(r => r.url().includes(`/credit-cards/${cardId}`) && r.request().method() === 'DELETE' && r.status() === 200, { timeout: 20000 }),
       card.locator(`.delete-card-btn[data-card-id="${cardId}"]`).click()
     ]);
+    const delCardBody = await delRespCard.json();
+    expect(delCardBody.message).toMatch(/credit card deleted/i);
   });
 
   test('should allow editing but still prevent deleting a protected credit card', async ({ page }) => {

--- a/frontend/e2e-tests/profile-bola.spec.ts
+++ b/frontend/e2e-tests/profile-bola.spec.ts
@@ -150,14 +150,16 @@ test.describe('Profile Page - BOLA Vulnerabilities', () => {
     await expect(cardToDelete).toBeVisible();
 
     page.once('dialog', d => d.accept());
-    await Promise.all([
+    const [delResp] = await Promise.all([
       page.waitForResponse(r =>
         r.url().includes(`/api/users/${grace.id}/credit-cards/${newlyCreatedCardIdForGrace}`) &&
         r.request().method() === 'DELETE' &&
-        r.status() === 204
+        r.status() === 200
       , { timeout: 20000 }),
       cardToDelete.locator('.delete-card-btn').click()
     ]);
+    const delBody = await delResp.json();
+    expect(delBody.message).toMatch(/credit card deleted/i);
 
     const successMsg = page.locator('#global-message-container .global-message.success-message');
     await expect(successMsg.filter({ hasText: `Credit card deleted successfully for ${grace.username}!` })).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- update Playwright tests to expect HTTP 200 for delete endpoints
- verify success messages from API JSON bodies

## Testing
- `npx playwright test frontend/e2e-tests/profile-address-management.spec.ts`
- `npx playwright test frontend/e2e-tests/admin-ui.spec.ts`
