### PR TITLE
Add role parameter for admin product creation

### DIFF
--- a/frontend/static/js/admin.js
+++ b/frontend/static/js/admin.js
@@ -40,6 +40,14 @@ document.addEventListener('DOMContentLoaded', function() {
             if (description) params.append('description', description);
             if (category) params.append('category', category);
 
+            // Default role parameter for consistency with fetchAdminProducts
+            params.append('role', 'user');
+
+            // Parameter pollution demo: escalate to admin if checkbox checked
+            if (adminEscalationCheckbox && adminEscalationCheckbox.checked) {
+                params.append('role', 'admin');
+            }
+
             // Parameter pollution for internal_status
             const internalStatusValue = document.getElementById('new-product-internal-status').value;
             if (internalStatusValue) {
@@ -47,6 +55,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (typeof displaySuccess === 'function') {
                     displaySuccess("Parameter Pollution Demo: Adding internal_status parameter to the request!");
                 }
+            } else if (revealInternalCheckbox && revealInternalCheckbox.checked) {
+                // Mirror "Show Internal Products" toggle for POST demo consistency
+                params.append('status', 'internal');
             }
             
             const endpoint = `/api/products?${params.toString()}`;


### PR DESCRIPTION
## Summary
- include `role` query params based on Parameter Pollution checkboxes when adding products
- default to `role=user` and append `role=admin` if escalation is selected
- allow `status=internal` when reveal internal checkbox is active

## Testing
- `npx playwright test frontend/e2e-tests/admin-ui.spec.ts`