### PR TITLE
Refactor notifications to top-right popups

### DIFF
--- a/frontend/e2e-tests/auth.spec.ts
+++ b/frontend/e2e-tests/auth.spec.ts
@@ -40,7 +40,7 @@ test.describe('User Authentication', () => {
 
     await expect(page).toHaveURL(/\/login/);
     await expect(
-      page.locator('main #error-message-container')
+      page.locator('#global-message-container .global-message.error-message')
     ).toContainText('Error: Login failed: Incorrect username or password');
   });
   

--- a/frontend/e2e-tests/cart.spec.ts
+++ b/frontend/e2e-tests/cart.spec.ts
@@ -106,7 +106,9 @@ test.describe('Shopping Cart', () => {
     const initialTotal = await getMoney(page, '#cart-total');
     await page.fill('#promo-code', 'TESTCODE');
     await page.locator('#promo-form button[type="submit"]').click();
-    await expect(page.locator('#success-message-container .success-message')).toBeVisible();
+    await expect(
+      page.locator('#global-message-container .global-message.success-message')
+    ).toBeVisible();
     await expect(page.locator('.summary-line.discount')).toBeVisible();
     const finalTotal = await getMoney(page, '#cart-total');
     expect(finalTotal).toBeLessThan(initialTotal);

--- a/frontend/e2e-tests/vulnerabilities.spec.ts
+++ b/frontend/e2e-tests/vulnerabilities.spec.ts
@@ -119,7 +119,7 @@ test.describe('Vulnerability Demonstrations', () => {
     page.once('dialog', dialog => dialog.accept());
     await page.locator(`#admin-products-container tr:has-text("${productName}") button.delete-product-btn`).click();
     const deleteSuccessLocator = page.locator(
-      '#success-message-container .success-message, #global-message-container .global-message.success-message',
+      '#global-message-container .global-message.success-message',
       { hasText: /deleted/ }
     );
     await expect(deleteSuccessLocator).toBeVisible({ timeout: 15000 }).catch(() => {});

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -303,7 +303,7 @@ footer {
 }
 
 /* Global Message System */
-#global-messages-container {
+#global-message-container {
     position: fixed;
     top: 20px;
     right: 20px;

--- a/frontend/static/js/helpers.js
+++ b/frontend/static/js/helpers.js
@@ -11,11 +11,11 @@ function displayGlobalMessage(message, type = 'info', duration = 5000) {
     if (!container) return;
     
     // Check if we already have a messages container
-    let messagesContainer = document.getElementById('global-messages-container');
+    let messagesContainer = document.getElementById('global-message-container');
     
     if (!messagesContainer) {
         messagesContainer = document.createElement('div');
-        messagesContainer.id = 'global-messages-container';
+        messagesContainer.id = 'global-message-container';
         container.appendChild(messagesContainer);
     }
     

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -100,47 +100,20 @@ async function apiCall(endpoint, method = 'GET', body = null, requiresAuth = tru
     }
 }
 
-function displayError(message, containerId = 'error-message-container') {
-    const container = document.getElementById(containerId);
-    if (container) {
-        container.innerHTML = `<div class="error-message"><strong>Error:</strong> ${message}</div>`;
-        container.style.display = 'block';
-        setTimeout(() => { clearError(containerId); }, 8000);
-    } else {
-        displayGlobalMessage(message, 'error');
-    }
+function displayError(message, _containerId = 'error-message-container') {
+    displayGlobalMessage(`<strong>Error:</strong> ${message}`, 'error');
 }
 
-function clearError(containerId = 'error-message-container') {
-    const container = document.getElementById(containerId);
-    if (container) {
-        container.innerHTML = '';
-        container.style.display = 'none';
-    }
-    const genericErrorContainer = document.getElementById('global-error-container');
-    if (genericErrorContainer) {
-        genericErrorContainer.innerHTML = '';
-        genericErrorContainer.style.display = 'none';
-    }
+function clearError(_containerId = 'error-message-container') {
+    /* Deprecated container-based errors now use global pop-ups */
 }
 
-function displaySuccess(message, containerId = 'success-message-container') {
-    const container = document.getElementById(containerId);
-    if (container) {
-        container.innerHTML = `<div class="success-message"><strong>Success:</strong> ${message}</div>`;
-        container.style.display = 'block';
-        setTimeout(() => { clearSuccess(containerId); }, 5000);
-    } else {
-        displayGlobalMessage(message, 'success');
-    }
+function displaySuccess(message, _containerId = 'success-message-container') {
+    displayGlobalMessage(`<strong>Success:</strong> ${message}`, 'success');
 }
 
-function clearSuccess(containerId = 'success-message-container') {
-    const container = document.getElementById(containerId);
-    if (container) {
-        container.innerHTML = '';
-        container.style.display = 'none';
-    }
+function clearSuccess(_containerId = 'success-message-container') {
+    /* Deprecated container-based success messages now use global pop-ups */
 }
 
 function initializeUIVulnerabilityFeaturesToggle() {

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -121,10 +121,8 @@
         </div>
     </footer>
 
-    <!-- Message Containers -->
+    <!-- Global Message Container -->
     <div id="global-message-container"></div>
-    <div id="error-message-container" style="display:none;"></div>
-    <div id="success-message-container" style="display:none;"></div>
 
     <!-- JavaScript -->
     <script src="/static/js/main.js"></script>

--- a/frontend/templates/cart.html
+++ b/frontend/templates/cart.html
@@ -8,9 +8,7 @@
         <h1>Your Shopping Cart</h1>
     </div>
     
-    <div id="error-message-container" style="display: none;"></div>
-    <div id="success-message-container" style="display: none;"></div>
-    
+
     <div class="cart-content-wrapper">
         <div id="cart-loading" class="cart-loading">
             <div class="loading-spinner"></div>

--- a/frontend/templates/checkout.html
+++ b/frontend/templates/checkout.html
@@ -171,7 +171,6 @@
     <div style="text-align:right; margin-top: 24px;">
         <button type="submit" form="checkout-form" id="place-order-btn" class="btn btn-primary btn-lg">Place Order</button>
     </div>
-    <div id="global-message-container"></div> 
 </div>
 {% endblock %}
 

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -35,9 +35,7 @@
         </div>
     </section>
     
-    <div id="error-message-container" style="display: none;"></div>
-    <div id="success-message-container" style="display: none;"></div>
-    
+
     <!-- Toast notification element -->
     <div id="toast-notification" class="toast-notification" data-testid="toast-notification"></div>
 {% endblock %}

--- a/frontend/templates/login.html
+++ b/frontend/templates/login.html
@@ -21,7 +21,6 @@
         <p>Don't have an account? <a href="/register">Register</a></p>
     </div>
     
-    <div id="error-message-container"></div>
 {% endblock %}
 
 {% block extra_js %}

--- a/frontend/templates/orders.html
+++ b/frontend/templates/orders.html
@@ -2,9 +2,7 @@
 
 {% block content %}
     <h1>Order History</h1>
-    <div id="error-message-container"></div>
-    <div id="success-message-container"></div>
-    
+
     <!-- BOLA Demo - View Other User's Orders -->
     <div class="vulnerability-demo-section">
         <h2>BOLA Vulnerability Demo: Access Other Users' Orders</h2>

--- a/frontend/templates/product_detail.html
+++ b/frontend/templates/product_detail.html
@@ -33,8 +33,6 @@
             <!-- Product details will be loaded here by JavaScript (from main.js) -->
         </div>
         
-        <div id="error-message-container" style="display:none;"></div>
-
         <!-- Parameter Pollution Demo Section -->
         <div class="vulnerability-demo-section card-style">
             <h2>Parameter Pollution Demo</h2>

--- a/frontend/templates/profile.html
+++ b/frontend/templates/profile.html
@@ -14,8 +14,6 @@
         <h1 id="profile-page-title">Your Profile</h1>
     </div>
 
-    <div id="global-message-container"></div> <!-- For global messages -->
-    
     <!-- Indicator for whose profile is being viewed -->
     <div id="profile-view-indicator" class="current-viewing-indicator" style="display: none;">
         Currently viewing: <strong id="current-viewing-username-span">Your Profile</strong>

--- a/frontend/templates/register.html
+++ b/frontend/templates/register.html
@@ -31,7 +31,6 @@
         <p>Already have an account? <a href="/login">Login</a></p>
     </div>
     
-    <div id="error-message-container"></div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Notes
- Environment doesn't have network access after setup, so Playwright tests could not complete.

## Summary
- style toast container and messages for global notifications
- remove old per-page message containers in templates
- update displayError/Success wrappers to use global pop-up messages
- adjust Playwright tests for new selectors

## Testing
- `npx playwright test frontend/e2e-tests/` *(fails: Test was interrupted)*