### PR TITLE
Remove special rule for Bob Johnson credit card

### DIFF
--- a/app/routers/user_router.py
+++ b/app/routers/user_router.py
@@ -457,42 +457,6 @@ async def update_user_credit_card(
             status_code=status.HTTP_400_BAD_REQUEST, detail="No update data provided"
         )
 
-    if (
-        hasattr(credit_card_to_update, "is_protected")
-        and credit_card_to_update.is_protected
-    ):
-        if (
-            str(credit_card_to_update.card_id) == "cc000003-0002-0000-0000-000000000002"
-            and str(user_id) == "00000003-0000-0000-0000-000000000003"
-        ):
-            allowed_updates_for_bob_card = {}
-            if (
-                "expiry_year" in update_data_dict
-                and update_data_dict["expiry_year"] == "2031"
-            ):
-                allowed_updates_for_bob_card["expiry_year"] = "2031"
-            if (
-                "is_default" in update_data_dict
-                and update_data_dict["is_default"] is True
-            ):
-                allowed_updates_for_bob_card["is_default"] = True
-
-            is_subset = all(
-                key in allowed_updates_for_bob_card for key in update_data_dict
-            )
-
-            if not is_subset or not update_data_dict:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=(
-                        "For this protected card (Bob's demo card), only specific updates "
-                        "(expiry_year to 2031, is_default to true) are permitted for the demo flow."
-                    ),
-                )
-            update_data_dict = allowed_updates_for_bob_card
-        else:
-            pass
-
     # If is_default is True, simply make this card default and unset others.
 
     for key, value in update_data_dict.items():

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -3036,9 +3036,8 @@ function populateCardFormForEdit(cardId, allCards) {
         cardCvvInput.disabled = true;
     }
 
-    const isSpecialCard = card.card_id === 'cc000003-0002-0000-0000-000000000002';
     if (protectedNote) protectedNote.style.display = card.is_protected ? 'block' : 'none';
-    if (cardholderInput) cardholderInput.disabled = isSpecialCard;
+    if (cardholderInput) cardholderInput.disabled = false;
     if (expiryMonthInput) expiryMonthInput.disabled = false;
     if (expiryYearInput) expiryYearInput.disabled = false;
     


### PR DESCRIPTION
## Summary
- remove Bob Johnson specific update restriction in user router
- allow editing Bob's secondary credit card in UI
- update Playwright tests to verify editing Bob's card works
- add functional tests for Bob's card updates and last card deletion
- remove obsolete test for special card rule

## Testing
- `pytest tests/test_functional.py::test_protected_bob_card_general_update -v`
- `pytest tests/test_functional.py::test_protected_bob_last_card_deletion_forbidden -v`
- `npx playwright test frontend/e2e-tests/profile-bola.spec.ts -g "secondary card" --project=chromium --timeout=60000`