### PR TITLE
Fix API base URL detection

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -6,11 +6,9 @@ const isLocal =
   window.location.hostname === '127.0.0.1';
 
 if (isLocal) {
-  // Dev environment, API likely on port 8000
   API_BASE_URL = 'http://localhost:8000';
 } else {
-  // Deployed environment - ensure protocol matches current page
-  API_BASE_URL = `${window.location.protocol}//${window.location.host}`;
+  API_BASE_URL = window.location.origin;
 }
 console.log(`[main.js] API_BASE_URL set to: ${API_BASE_URL}`); // For debugging
 let authToken = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- set API_BASE_URL using `window.location.origin`
- adjust environment logic so deployed site uses current origin

## Testing
- `npx playwright test frontend/e2e-tests/homepage.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_683ee5cf5fb88320a84d248fded007c2