### PR TITLE
Fix FOUC for UI demos

### DIFF
--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -5091,3 +5091,30 @@ nav.breadcrumb .current-page {
     margin-top: 5px;
 }
 
+/* Default hidden state for vulnerability demo dependent UI elements */
+.ui-demo-dependant,
+.ui-demo-dependant-block,
+.ui-demo-dependant-flex,
+.ui-demo-dependant-grid,
+.ui-demo-dependant-inline-block {
+    display: none !important;
+}
+
+/* Visible states controlled via JavaScript */
+.ui-demo-dependant.demo-visible,
+.ui-demo-dependant-block.demo-visible {
+    display: block !important;
+}
+
+.ui-demo-dependant-flex.demo-visible {
+    display: flex !important;
+}
+
+.ui-demo-dependant-grid.demo-visible {
+    display: grid !important;
+}
+
+.ui-demo-dependant-inline-block.demo-visible {
+    display: inline-block !important;
+}
+

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -326,43 +326,36 @@ function hidePageLoader() {
 // Full unabridged function with the specified changes, maintaining original structure for Profile Page logic.
 function updateUIVulnerabilityFeaturesDisplay() {
     console.log(`UI Vulnerability Demos are now: ${uiVulnerabilityFeaturesEnabled ? 'ENABLED' : 'DISABLED'}`);
-    const displayStyleForBlock = uiVulnerabilityFeaturesEnabled ? 'block' : 'none';
-    const displayStyleForFlex = uiVulnerabilityFeaturesEnabled ? 'flex' : 'none'; // Keep this if used elsewhere
-
-    const toggleVisibilityBySelector = (selector, show, defaultDisplay = 'block') => {
-        document.querySelectorAll(selector).forEach(el => {
-            el.style.display = show ? defaultDisplay : 'none';
-        });
-    };
-
-    const toggleVisibilityById = (elementId, show, defaultDisplay = 'block') => {
-        const element = document.getElementById(elementId);
-        if (element) {
-            element.style.display = show ? defaultDisplay : 'none';
+    const demoElements = document.querySelectorAll(
+        '.ui-demo-dependant, .ui-demo-dependant-block, .ui-demo-dependant-flex, .ui-demo-dependant-grid, .ui-demo-dependant-inline-block'
+    );
+    demoElements.forEach((el) => {
+        if (uiVulnerabilityFeaturesEnabled) {
+            el.classList.add('demo-visible');
+        } else {
+            el.classList.remove('demo-visible');
         }
-    };
+    });
 
     // --- Home Page (`index.html`) ---
     if (document.getElementById('search-info')) {
         const searchInfoDiv = document.getElementById('search-info');
         const searchTermInput = document.getElementById('search-term');
         if (searchInfoDiv && searchTermInput) {
-            // Remove any existing handlers to avoid duplicates when toggling
             searchTermInput.onfocus = null;
             searchTermInput.onblur = null;
 
             if (uiVulnerabilityFeaturesEnabled) {
                 searchTermInput.onfocus = function () {
-                    searchInfoDiv.style.display = 'block';
+                    searchInfoDiv.classList.add('demo-visible');
                 };
                 searchTermInput.onblur = function () {
                     if (this.value === '') {
-                        searchInfoDiv.style.display = 'none';
+                        searchInfoDiv.classList.remove('demo-visible');
                     }
                 };
-                searchInfoDiv.style.display = 'none';
             } else {
-                searchInfoDiv.style.display = 'none';
+                searchInfoDiv.classList.remove('demo-visible');
             }
         }
     }
@@ -372,16 +365,34 @@ function updateUIVulnerabilityFeaturesDisplay() {
         // Visibility of BOLA Demo Sections (User Discovery, Update Profile for BOLA)
         const profileBolaDemoSection = Array.from(document.querySelectorAll('.vulnerability-demo-section'))
             .find(section => section.querySelector('#discover-users-btn'));
-        if (profileBolaDemoSection) profileBolaDemoSection.style.display = displayStyleForBlock;
+        if (profileBolaDemoSection) {
+            if (uiVulnerabilityFeaturesEnabled) {
+                profileBolaDemoSection.classList.add('demo-visible');
+            } else {
+                profileBolaDemoSection.classList.remove('demo-visible');
+            }
+        }
         
         const bolaUpdateProfileDemoSection = Array.from(document.querySelectorAll('.vulnerability-demo-section h4'))
             .find(h4 => h4.textContent.includes('BOLA Demo: Update Profile'))?.closest('.vulnerability-demo-section');
-        if (bolaUpdateProfileDemoSection) bolaUpdateProfileDemoSection.style.display = displayStyleForBlock;
+        if (bolaUpdateProfileDemoSection) {
+            if (uiVulnerabilityFeaturesEnabled) {
+                bolaUpdateProfileDemoSection.classList.add('demo-visible');
+            } else {
+                bolaUpdateProfileDemoSection.classList.remove('demo-visible');
+            }
+        }
 
         // Visibility of Parameter Pollution Demo Section
         const adminEscalationDemoSection = Array.from(document.querySelectorAll('.vulnerability-demo-section h4'))
             .find(h4 => h4.textContent.includes('Parameter Pollution Demo: Admin Escalation'))?.closest('.vulnerability-demo-section');
-        if (adminEscalationDemoSection) adminEscalationDemoSection.style.display = displayStyleForBlock;
+        if (adminEscalationDemoSection) {
+            if (uiVulnerabilityFeaturesEnabled) {
+                adminEscalationDemoSection.classList.add('demo-visible');
+            } else {
+                adminEscalationDemoSection.classList.remove('demo-visible');
+            }
+        }
 
         // Control visibility of "Currently viewing" indicator
         const profileViewIndicator = document.getElementById('profile-view-indicator');
@@ -395,19 +406,22 @@ function updateUIVulnerabilityFeaturesDisplay() {
                 } else if (currentViewingUsernameSpan && currentUser) { // Fallback if BOLA state vars not fully set yet
                      currentViewingUsernameSpan.textContent = `${currentUser.username}'s Profile`; // Default to own profile text
                 }
-                profileViewIndicator.style.display = 'block';
+                profileViewIndicator.classList.add('demo-visible');
             } else {
-                profileViewIndicator.style.display = 'none';
+                profileViewIndicator.classList.remove('demo-visible');
             }
         }
         
         // BOLA Active Banner (Warns when viewing another user's profile with demos ON)
         const bolaDemoActiveBanner = document.getElementById('bola-demo-active-banner');
-        if (bolaDemoActiveBanner && currentUser) { // Ensure currentUser is available
-             // Show banner only if UI Demos are ON AND viewing another user's profile
-            bolaDemoActiveBanner.style.display = (uiVulnerabilityFeaturesEnabled && typeof currentlyViewedUserId !== 'undefined' && currentlyViewedUserId !== currentUser.user_id) ? 'block' : 'none';
+        if (bolaDemoActiveBanner && currentUser) {
+            if (uiVulnerabilityFeaturesEnabled && typeof currentlyViewedUserId !== 'undefined' && currentlyViewedUserId !== currentUser.user_id) {
+                bolaDemoActiveBanner.classList.add('demo-visible');
+            } else {
+                bolaDemoActiveBanner.classList.remove('demo-visible');
+            }
         } else if (bolaDemoActiveBanner) {
-            bolaDemoActiveBanner.style.display = 'none'; // Hide if currentUser isn't defined
+            bolaDemoActiveBanner.classList.remove('demo-visible');
         }
 
         // Logic for "Discover Users" and "Return to My Profile" buttons
@@ -418,14 +432,9 @@ function updateUIVulnerabilityFeaturesDisplay() {
 
         if (!uiVulnerabilityFeaturesEnabled) {
             // UI Demos are OFF
-            if (discoveredUsersContainer) discoveredUsersContainer.style.display = 'none';
-            if (returnBtn) returnBtn.style.display = 'none'; 
-            // The discoverBtn's parent section will be hidden, so discoverBtn will also be hidden.
-            if (profileBolaDemoSection && profileBolaDemoSection.style.display === 'none') {
-                 if (discoverBtn) discoverBtn.style.display = 'none';
-            } else if (discoverBtn) { 
-                 discoverBtn.style.display = 'none';
-            }
+            if (discoveredUsersContainer) discoveredUsersContainer.classList.remove('demo-visible');
+            if (returnBtn) returnBtn.classList.remove('demo-visible');
+            if (discoverBtn) discoverBtn.classList.remove('demo-visible');
 
             // If demos are turned OFF while viewing another user's BOLA profile, revert view to own profile.
             if (currentUser && hiddenUserIdInput && hiddenUserIdInput.value && hiddenUserIdInput.value !== currentUser.user_id) {
@@ -446,13 +455,13 @@ function updateUIVulnerabilityFeaturesDisplay() {
             if (discoverBtn && returnBtn) { 
                 if (currentUser && hiddenUserIdInput && hiddenUserIdInput.value && hiddenUserIdInput.value !== currentUser.user_id) {
                     // Viewing another user's profile (BOLA active)
-                    returnBtn.style.display = 'inline-block';
-                    discoverBtn.style.display = 'none';
-                    if (discoveredUsersContainer) discoveredUsersContainer.style.display = 'none'; 
+                    returnBtn.classList.add('demo-visible');
+                    discoverBtn.classList.remove('demo-visible');
+                    if (discoveredUsersContainer) discoveredUsersContainer.classList.remove('demo-visible');
                 } else {
                     // Viewing own profile or not yet selected a victim
-                    returnBtn.style.display = 'none';
-                    discoverBtn.style.display = 'inline-block'; 
+                    returnBtn.classList.remove('demo-visible');
+                    discoverBtn.classList.add('demo-visible');
                 }
             }
         }
@@ -466,7 +475,13 @@ function updateUIVulnerabilityFeaturesDisplay() {
     // --- Admin Page (`admin_products.html`) ---
     if (document.querySelector('.admin-section h1')?.textContent === 'Admin Dashboard') {
         const ppSection = document.querySelector('.parameter-pollution-controls');
-        if (ppSection) ppSection.style.display = uiVulnerabilityFeaturesEnabled ? 'block' : 'none';
+        if (ppSection) {
+            if (uiVulnerabilityFeaturesEnabled) {
+                ppSection.classList.add('demo-visible');
+            } else {
+                ppSection.classList.remove('demo-visible');
+            }
+        }
 
         if (typeof applyAdminPageDisplay === 'function') {
             applyAdminPageDisplay();
@@ -477,7 +492,11 @@ function updateUIVulnerabilityFeaturesDisplay() {
     if (document.getElementById('product-detail-page-body')) {
         const productPollutionDemoSection = document.querySelector('#product-detail-page-body .vulnerability-demo-section');
         if (productPollutionDemoSection) {
-            productPollutionDemoSection.style.display = displayStyleForBlock;
+            if (uiVulnerabilityFeaturesEnabled) {
+                productPollutionDemoSection.classList.add('demo-visible');
+            } else {
+                productPollutionDemoSection.classList.remove('demo-visible');
+            }
         }
 
         const internalStatusInfoDiv = document.querySelector('.internal-status-badge'); 
@@ -503,32 +522,40 @@ function updateUIVulnerabilityFeaturesDisplay() {
         if (placeOrderBtn) placeOrderBtn.style.display = 'inline-block';
 
         if (uiVulnerabilityFeaturesEnabled) {
-            // Show the main BOLA demo section
-            if (bolaDemoSection) bolaDemoSection.style.display = 'block';
+            if (bolaDemoSection) bolaDemoSection.classList.add('demo-visible');
+            if (bolaCheckboxLabelContainer) bolaCheckboxLabelContainer.classList.add('demo-visible');
 
-            // Show the "Enable BOLA Exploit Mode" checkbox
-            if (bolaCheckboxLabelContainer) bolaCheckboxLabelContainer.style.display = 'flex';
-
-            // Visibility of BOLA input fields and warning depends on the checkbox state
-            if (bolaCheckbox && bolaFields) bolaFields.style.display = bolaCheckbox.checked ? 'block' : 'none';
-            if (bolaCheckbox && bolaWarningContainer) bolaWarningContainer.style.display = bolaCheckbox.checked ? 'block' : 'none';
+            if (bolaCheckbox && bolaFields) {
+                if (bolaCheckbox.checked) {
+                    bolaFields.classList.add('demo-visible');
+                    bolaWarningContainer?.classList.add('demo-visible');
+                } else {
+                    bolaFields.classList.remove('demo-visible');
+                    bolaWarningContainer?.classList.remove('demo-visible');
+                }
+            }
         } else {
-            // Demos are OFF: Hide all BOLA-specific UI elements
-            if (bolaDemoSection) bolaDemoSection.style.display = 'none';
-            if (bolaCheckboxLabelContainer) bolaCheckboxLabelContainer.style.display = 'none';
+            if (bolaDemoSection) bolaDemoSection.classList.remove('demo-visible');
+            if (bolaCheckboxLabelContainer) bolaCheckboxLabelContainer.classList.remove('demo-visible');
             if (bolaCheckbox) bolaCheckbox.checked = false;
-            if (bolaFields) bolaFields.style.display = 'none';
-            if (bolaWarningContainer) bolaWarningContainer.style.display = 'none';
+            if (bolaFields) bolaFields.classList.remove('demo-visible');
+            if (bolaWarningContainer) bolaWarningContainer.classList.remove('demo-visible');
         }
     }
 
     // --- Orders Page (`orders.html`) ---
     if (document.getElementById('orders-container')) {
-         toggleVisibilityBySelector('.vulnerability-demo-section', uiVulnerabilityFeaturesEnabled); 
+        document.querySelectorAll('.vulnerability-demo-section').forEach((el) => {
+            if (uiVulnerabilityFeaturesEnabled) {
+                el.classList.add('demo-visible');
+            } else {
+                el.classList.remove('demo-visible');
+            }
+        });
 
         const currentViewingDivOrders = document.getElementById('current-viewing'); 
         if (!uiVulnerabilityFeaturesEnabled) {
-            if (currentViewingDivOrders) currentViewingDivOrders.style.display = 'none';
+            if (currentViewingDivOrders) currentViewingDivOrders.classList.remove('demo-visible');
             const targetUserIdInputInForm = document.querySelector('#view-orders-form #target-user-id');
             if (targetUserIdInputInForm) targetUserIdInputInForm.value = ''; 
 
@@ -549,10 +576,10 @@ function updateUIVulnerabilityFeaturesDisplay() {
             // If currently viewing another user's orders (BOLA state), ensure the "current-viewing" banner is visible.
             const viewingUserIdHiddenInputOrders = document.getElementById('viewing-user-id-orders');
             if (currentViewingDivOrders && viewingUserIdHiddenInputOrders && currentUser && viewingUserIdHiddenInputOrders.value !== currentUser.user_id) {
-                currentViewingDivOrders.style.display = 'flex'; // Ensure it's flex if BOLA active and demos ON
+                currentViewingDivOrders.classList.add('demo-visible');
                 // The text content of this banner is handled by fetchAndDisplayOrders
             } else if (currentViewingDivOrders) {
-                currentViewingDivOrders.style.display = 'none'; // Hide if viewing own orders
+                currentViewingDivOrders.classList.remove('demo-visible');
             }
         }
     }
@@ -636,16 +663,15 @@ function initHomePage() {
     if (searchInfoDiv && searchTermInput) {
         if (uiVulnerabilityFeaturesEnabled) {
             searchTermInput.addEventListener('focus', function () {
-                searchInfoDiv.style.display = 'block';
+                searchInfoDiv.classList.add('demo-visible');
             });
             searchTermInput.addEventListener('blur', function () {
                 if (this.value === '') {
-                    searchInfoDiv.style.display = 'none';
+                    searchInfoDiv.classList.remove('demo-visible');
                 }
             });
-            searchInfoDiv.style.display = 'none';
         } else {
-            searchInfoDiv.style.display = 'none';
+            searchInfoDiv.classList.remove('demo-visible');
         }
     }
     updateUIVulnerabilityFeaturesDisplay();
@@ -791,13 +817,13 @@ function setupProfilePageEventListeners() {
         }
         
         const discoveredUsersContainer = document.getElementById('discovered-users-container');
-        if(discoveredUsersContainer) discoveredUsersContainer.style.display = 'none';
+        if (discoveredUsersContainer) discoveredUsersContainer.classList.remove('demo-visible');
         
         const returnBtn = document.getElementById('return-to-my-profile-btn');
-        if(returnBtn) returnBtn.style.display = 'none';
+        if (returnBtn) returnBtn.classList.remove('demo-visible');
         
         const discoverBtn = document.getElementById('discover-users-btn');
-        if(discoverBtn) discoverBtn.style.display = 'inline-block';
+        if (discoverBtn) discoverBtn.classList.add('demo-visible');
 
         fetchAndDisplayFullProfile(currentlyViewedUserId);
         displayGlobalMessage('Returned to viewing your own profile.', 'info');

--- a/frontend/templates/admin_products.html
+++ b/frontend/templates/admin_products.html
@@ -12,7 +12,7 @@
     <div id="global-success-container"></div>
 
     <!-- BFLA Vulnerability Demo Banner -->
-    <div id="vulnerability-banner-admin" class="vulnerability-warning" style="display: none;">
+    <div id="vulnerability-banner-admin" class="vulnerability-warning ui-demo-dependant">
         <button type="button" class="close-btn" onclick="this.parentElement.style.display='none'">&times;</button>
         <h3><i class="fas fa-exclamation-triangle"></i> BFLA Vulnerability Demo Active</h3>
         <p>You are currently accessing admin functions with escalated privileges or viewing internal data due to a simulated BFLA condition. This is for demonstration purposes.</p>
@@ -21,7 +21,7 @@
     <h2>Products Management</h2>
 
     <!-- Parameter Pollution Demo Section -->
-    <div class="parameter-pollution-controls vulnerability-demo-section card-style">
+    <div class="parameter-pollution-controls vulnerability-demo-section card-style ui-demo-dependant">
         <h2><i class="fas fa-filter-circle-dollar"></i> Parameter Pollution Demo Options</h2>
         <p>These options demonstrate API parameter pollution vulnerabilities by adding extra query parameters to the product list request. Observe the "Demo URL" to see the effect.</p>
         <div class="form-check">
@@ -50,7 +50,7 @@
         <!-- Products table will be loaded here by admin.js -->
     </div>
 
-        <div class="add-product-section">
+        <div class="add-product-section ui-demo-dependant">
             <h3 id="add-product-header"><span class="exploit-indicator">BFLA</span> Demo: Add New Product</h3>
         <p id="add-product-helper" class="helper-text">This form demonstrates adding a product as a non-admin. If successful, it indicates a BFLA vulnerability.</p>
         <form id="add-product-form">
@@ -83,7 +83,7 @@
         </form>
     </div>
 
-    <div class="update-stock-section" style="margin-top: 30px;">
+    <div class="update-stock-section ui-demo-dependant" style="margin-top: 30px;">
         <h3 id="update-stock-header"><span class="exploit-indicator">BFLA</span> Demo: Update Product Stock</h3>
         <p id="update-stock-helper" class="helper-text">Any user can modify stock quantities without authorization.</p>
         <form id="update-stock-form">
@@ -99,7 +99,7 @@
         </form>
     </div>
 
-    <div class="delete-user-section" style="margin-top: 30px;">
+    <div class="delete-user-section ui-demo-dependant" style="margin-top: 30px;">
         <h3><span class="exploit-indicator">BFLA</span> Demo: Delete User Account</h3>
         <p class="helper-text">Demonstrates deleting any user. This action should be restricted to administrators.</p>
         <form id="delete-user-form">

--- a/frontend/templates/checkout.html
+++ b/frontend/templates/checkout.html
@@ -83,26 +83,26 @@
         </div>
 
         <!-- BOLA Demo Section - only contains BOLA specific UI -->
-        <div id="bola-demo-section" class="vulnerability-demo-section card-style" style="margin-top: 1.5rem; display: none;">
+        <div id="bola-demo-section" class="vulnerability-demo-section card-style ui-demo-dependant" style="margin-top: 1.5rem;">
             <h2>
                 <svg class="vulnerability-icon" viewBox="0 0 24 24" width="24" height="24" fill="var(--danger-color)">
                     <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/>
                 </svg>
                 BOLA Vulnerability Demo: Order with Another User's Payment
             </h2>
-            <div id="bola-warning-container" class="vulnerability-warning" style="display: none;">
+            <div id="bola-warning-container" class="vulnerability-warning ui-demo-dependant">
                 <!-- JS will populate this if BOLA checkbox is checked -->
             </div>
             <div id="bola-demo-form" class="vulnerability-exploit-section" style="margin-top: 1.5rem;">
                 <h3><span class="exploit-indicator">BOLA</span> Exploit Configuration</h3>
                 <p class="vulnerability-info">Use these fields to attempt to use another user's details. If "Target User ID" is blank, the order is for you. If "Target Address ID" is blank, your selected address above (or your default) will be used for shipping. <strong>To exploit payment BOLA, you MUST provide a "Target Credit Card ID".</strong></p>
-                <div class="form-group">
+                <div class="form-group ui-demo-dependant-flex">
                     <label class="vulnerability-input-label">
                         <input type="checkbox" id="order-for-other-user" name="order-for-other-user" data-testid="bola-checkbox">
                         <span class="checkbox-text">Enable BOLA Exploit Mode</span>
                     </label>
                 </div>
-                <div id="bola-demo-fields" style="display: none;">
+                <div id="bola-demo-fields" class="ui-demo-dependant">
                     <div class="attack-steps">
                         <div class="attack-step">
                             <span class="step-number">1</span>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -16,7 +16,7 @@
                         Search
                     </button>
                 </div>
-                <div id="search-info" class="search-info" data-testid="search-info">
+                <div id="search-info" class="search-info ui-demo-dependant" data-testid="search-info">
                     <p><strong>Note:</strong> This search feature demonstrates potential injection vulnerabilities.</p>
                 </div>
             </form>

--- a/frontend/templates/orders.html
+++ b/frontend/templates/orders.html
@@ -24,7 +24,7 @@
             <button type="submit" class="btn-exploit">View Another User's Orders</button>
         </form>
         
-        <div id="current-viewing" style="display: none;" class="current-viewing-indicator">
+        <div id="current-viewing" class="current-viewing-indicator ui-demo-dependant-flex">
             <strong>Currently viewing orders for:</strong> <span id="viewing-username"></span> (User ID: <span id="viewing-user-id-display"></span>)
             <button id="return-to-own-orders" class="btn-secondary btn-sm">Return to Your Orders</button>
         </div>

--- a/frontend/templates/product_detail.html
+++ b/frontend/templates/product_detail.html
@@ -34,7 +34,7 @@
         </div>
         
         <!-- Parameter Pollution Demo Section -->
-        <div class="vulnerability-demo-section card-style">
+        <div class="vulnerability-demo-section card-style ui-demo-dependant">
             <h2>Parameter Pollution Demo</h2>
             <p>This demonstrates how parameter pollution can be used to modify the internal status of a product. For example, try adding <code>&internal_status=discontinued</code> to the URL when this page loads a product.</p>
             <form id="parameter-pollution-form">

--- a/frontend/templates/profile.html
+++ b/frontend/templates/profile.html
@@ -15,24 +15,24 @@
     </div>
 
     <!-- Indicator for whose profile is being viewed -->
-    <div id="profile-view-indicator" class="current-viewing-indicator" style="display: none;">
+    <div id="profile-view-indicator" class="current-viewing-indicator ui-demo-dependant">
         Currently viewing: <strong id="current-viewing-username-span">Your Profile</strong>
     </div>
-    <div id="bola-demo-active-banner" class="vulnerability-warning" style="display: none;">
+    <div id="bola-demo-active-banner" class="vulnerability-warning ui-demo-dependant">
         <h3><i class="fas fa-exclamation-triangle"></i> BOLA DEMO ACTIVE!</h3>
         <p>You are currently viewing and managing data for another user. Actions taken here will affect the selected victim's account.</p>
     </div>
 
 
     <!-- BOLA Vulnerability Demo Section: User Discovery -->
-    <div class="vulnerability-demo-section card-style">
+    <div class="vulnerability-demo-section card-style ui-demo-dependant">
         <h2>BOLA Vulnerability Demo: Access Other Users</h2>
         <p>Use the button below to discover other users (due to BFLA on <code>GET /api/users</code>). Then, select a user to view and manage their profile information (demonstrating BOLA).</p>
         <div class="demo-actions">
             <button id="discover-users-btn" class="btn btn-warning btn-exploit"><i class="fas fa-users"></i> Discover Other Users (BFLA Exploit)</button>
-            <button id="return-to-my-profile-btn" class="btn btn-secondary" style="display: none;"><i class="fas fa-user-shield"></i> Return to My Profile</button>
+            <button id="return-to-my-profile-btn" class="btn btn-secondary ui-demo-dependant-inline-block"><i class="fas fa-user-shield"></i> Return to My Profile</button>
         </div>
-        <div id="discovered-users-container" style="display: none;" class="mt-3">
+        <div id="discovered-users-container" class="mt-3 ui-demo-dependant">
             <h4>Select a Victim User to Target:</h4>
             <ul id="discovered-users-list" class="list-group">
                 <!-- User list will be populated here -->
@@ -59,13 +59,13 @@
             </form>
         </div>
         <!-- Parameter Pollution Demo: Admin Escalation -->
-        <div class="vulnerability-demo-section" style="margin-top: 20px; padding:15px; background-color: #fff8e1;">
+        <div class="vulnerability-demo-section ui-demo-dependant" style="margin-top: 20px; padding:15px; background-color: #fff8e1;">
             <h4>Parameter Pollution Demo: Admin Escalation</h4>
             <p>Attempt to escalate the privileges of the <strong id="escalation-target-username">currently viewed user</strong> by adding <code>is_admin=true</code> to the update request.</p>
             <button id="attempt-admin-escalation-btn" class="btn btn-danger btn-exploit"><i class="fas fa-user-secret"></i> Attempt Admin Escalation for <span id="escalation-target-btn-username">User</span></button>
         </div>
         <!-- BOLA Demo: Update Profile -->
-        <div class="vulnerability-demo-section" style="margin-top: 20px;">
+        <div class="vulnerability-demo-section ui-demo-dependant" style="margin-top: 20px;">
             <h4>BOLA Demo: Update Profile</h4>
             <p>While viewing another user's profile you can change their username or email.</p>
             <form id="update-profile-form" class="inline-form">


### PR DESCRIPTION
## Summary
- default hide vulnerability demo sections in CSS
- gate search info note on toggle and refactor JS visibility logic
- mark demo sections with ui-demo-dependant classes in templates
- update orders page demo banner
- adjust main.js to toggle `demo-visible` classes

## Testing
- `pytest tests/test_functional.py -v`
- `pytest tests/test_vulnerabilities.py -v`
- `npx playwright test frontend/e2e-tests/homepage.spec.ts frontend/e2e-tests/global-ui.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_683eebabfa6c8320ad2f83f7b6ca5575