### PR TITLE
Fix search endpoint path

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -687,7 +687,7 @@ async function handleProductSearch(e) {
     if (productGrid && !loadingIndicator) productGrid.innerHTML = '<p class="loading-indicator">Searching...</p>';
     
     try {
-        const endpoint = searchTerm ? `/api/products/search/?name=${encodeURIComponent(searchTerm)}` : '/api/products';
+        const endpoint = searchTerm ? `/api/products/search?name=${encodeURIComponent(searchTerm)}` : '/api/products';
         const products = await apiCall(endpoint, 'GET', null, false);
         renderProducts(products);
     } catch (error) {


### PR DESCRIPTION
## Summary
- update search API path to avoid trailing slash redirect

## Testing
- `npx playwright test frontend/e2e-tests/homepage.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_683ef4f2d0c883208d5e1a10478484ec