### PR TITLE
Add WebP mime support and test

### DIFF
--- a/frontend/e2e-tests/homepage.spec.ts
+++ b/frontend/e2e-tests/homepage.spec.ts
@@ -109,4 +109,24 @@ test.describe('Homepage and Product Listing', () => {
 
     expect(desktopGridStyle).not.toBe(mobileGridStyle);
   });
+
+  test('should request product images in webp format when supported', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'WebP check only on Chromium');
+
+    const webpResponses: any[] = [];
+    page.on('response', res => {
+      if (res.url().includes('/static/images/products') && res.url().endsWith('.webp')) {
+        webpResponses.push(res);
+      }
+    });
+
+    await page.goto('/');
+    await expect(page.locator('#loading-indicator')).toBeHidden({ timeout: 15000 });
+    await expect(page.locator('article.product-card').first()).toBeVisible({ timeout: 10000 });
+
+    await page.waitForTimeout(1000);
+    expect(webpResponses.length).toBeGreaterThan(0);
+    const contentType = webpResponses[0].headers()['content-type'];
+    expect(contentType).toContain('image/webp');
+  });
 });

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,8 @@
 server {
     listen 0.0.0.0:80;
     server_name _;
+    # Include standard MIME types so browsers receive correct headers
+    include /etc/nginx/mime.types;
 
     # --- Backend Specific Documentation Paths & Files ---
     location /docs {


### PR DESCRIPTION
## Summary
- serve WebP files with correct mime types through nginx
- verify webp delivery with new Playwright test

## Testing
- `pytest tests/test_functional.py -v`
- `pytest tests/test_vulnerabilities.py -v`
- `npx playwright test frontend/e2e-tests/homepage.spec.ts --workers=1`

------
https://chatgpt.com/codex/tasks/task_b_683f096b589c8320b8beb79cabc489ef