### PR TITLE
Fix UI demo toggle handling on orders and admin pages

### DIFF
--- a/frontend/static/js/admin.js
+++ b/frontend/static/js/admin.js
@@ -332,6 +332,7 @@ function updateVulnerabilityBanner() {
     updateConstructedUrlDisplay();
 }
 
+
 function applyAdminPageDisplay() {
     const isRealAdmin = currentUser && currentUser.is_admin;
     const demosOn = uiVulnerabilityFeaturesEnabled;
@@ -345,10 +346,13 @@ function applyAdminPageDisplay() {
         ppSection.style.display = demosOn ? 'block' : 'none';
     }
 
+    const addSection = document.querySelector('.add-product-section');
     const addHeader = document.getElementById('add-product-header');
     const addHelper = document.getElementById('add-product-helper');
     const addSubmit = document.getElementById('add-product-submit');
-    if (isRealAdmin || !demosOn) {
+
+    if (isRealAdmin) {
+        if (addSection) addSection.style.display = 'block';
         if (addHeader) addHeader.textContent = 'Add New Product';
         if (addHelper) addHelper.textContent = 'Add a new product to the catalog.';
         if (addSubmit) {
@@ -356,19 +360,25 @@ function applyAdminPageDisplay() {
             addSubmit.classList.add('btn-primary');
             addSubmit.textContent = 'Add Product';
         }
-    } else {
+    } else if (demosOn) {
+        if (addSection) addSection.style.display = 'block';
         if (addHeader) addHeader.innerHTML = '<span class="exploit-indicator">BFLA</span> Demo: Add New Product';
         if (addHelper) addHelper.textContent = 'This form demonstrates adding a product as a non-admin. If successful, it indicates a BFLA vulnerability.';
         if (addSubmit) {
             addSubmit.classList.add('btn-warning', 'btn-exploit');
             addSubmit.textContent = 'Add Product (Demo Exploit)';
         }
+    } else {
+        if (addSection) addSection.style.display = 'none';
     }
 
+    const updateSection = document.querySelector('.update-stock-section');
     const updateHeader = document.getElementById('update-stock-header');
     const updateHelper = document.getElementById('update-stock-helper');
     const updateSubmit = document.getElementById('update-stock-submit');
-    if (isRealAdmin || !demosOn) {
+
+    if (isRealAdmin) {
+        if (updateSection) updateSection.style.display = 'block';
         if (updateHeader) updateHeader.textContent = 'Update Product Stock';
         if (updateHelper) updateHelper.textContent = 'Update stock quantity for a product.';
         if (updateSubmit) {
@@ -376,13 +386,16 @@ function applyAdminPageDisplay() {
             updateSubmit.classList.add('btn-primary');
             updateSubmit.textContent = 'Update Stock';
         }
-    } else {
+    } else if (demosOn) {
+        if (updateSection) updateSection.style.display = 'block';
         if (updateHeader) updateHeader.innerHTML = '<span class="exploit-indicator">BFLA</span> Demo: Update Product Stock';
         if (updateHelper) updateHelper.textContent = 'Any user can modify stock quantities without authorization.';
         if (updateSubmit) {
             updateSubmit.classList.add('btn-warning', 'btn-exploit');
             updateSubmit.textContent = 'Update Stock (Demo Exploit)';
         }
+    } else {
+        if (updateSection) updateSection.style.display = 'none';
     }
 
     const deleteSection = document.querySelector('.delete-user-section');

--- a/frontend/templates/admin_products.html
+++ b/frontend/templates/admin_products.html
@@ -50,7 +50,7 @@
         <!-- Products table will be loaded here by admin.js -->
     </div>
 
-        <div class="add-product-section ui-demo-dependant">
+        <div class="add-product-section" style="display: none;">
             <h3 id="add-product-header"><span class="exploit-indicator">BFLA</span> Demo: Add New Product</h3>
         <p id="add-product-helper" class="helper-text">This form demonstrates adding a product as a non-admin. If successful, it indicates a BFLA vulnerability.</p>
         <form id="add-product-form">
@@ -83,7 +83,7 @@
         </form>
     </div>
 
-    <div class="update-stock-section ui-demo-dependant" style="margin-top: 30px;">
+    <div class="update-stock-section" style="margin-top: 30px; display: none;">
         <h3 id="update-stock-header"><span class="exploit-indicator">BFLA</span> Demo: Update Product Stock</h3>
         <p id="update-stock-helper" class="helper-text">Any user can modify stock quantities without authorization.</p>
         <form id="update-stock-form">
@@ -99,7 +99,7 @@
         </form>
     </div>
 
-    <div class="delete-user-section ui-demo-dependant" style="margin-top: 30px;">
+    <div class="delete-user-section" style="margin-top: 30px; display: none;">
         <h3><span class="exploit-indicator">BFLA</span> Demo: Delete User Account</h3>
         <p class="helper-text">Demonstrates deleting any user. This action should be restricted to administrators.</p>
         <form id="delete-user-form">

--- a/frontend/templates/orders.html
+++ b/frontend/templates/orders.html
@@ -4,7 +4,7 @@
     <h1>Order History</h1>
 
     <!-- BOLA Demo - View Other User's Orders -->
-    <div class="vulnerability-demo-section">
+    <div class="vulnerability-demo-section ui-demo-dependant">
         <h2>BOLA Vulnerability Demo: Access Other Users' Orders</h2>
         <div class="vulnerability-warning">
             <h3>Security Alert: Broken Object Level Authorization (BOLA)</h3>
@@ -30,14 +30,14 @@
         </div>
     </div>
 
-    <div class="vulnerability-demo-section">
+    <div class="vulnerability-demo-section ui-demo-dependant">
         <h2>List Users</h2>
         <p>This exposes the <code>GET /api/users</code> endpoint to any authenticated user.</p>
         <button type="button" id="list-users-btn" class="btn btn-warning btn-exploit">List Users</button>
         <ul id="users-list" class="list-group" style="margin-top:10px;"></ul>
     </div>
 
-    <div class="vulnerability-demo-section">
+    <div class="vulnerability-demo-section ui-demo-dependant">
         <h2>BOLA Demo: Order Detail</h2>
         <p>Retrieve a specific order for any user.</p>
         <form id="order-detail-form">


### PR DESCRIPTION
## Summary
- hide Orders page demos unless the UI Demo switch is on
- show admin dashboard actions properly when UI demos are off
- adjust admin demo logic to hide features from non-admins when demos disabled

## Testing
- `npx playwright test frontend/e2e-tests/orders-ui.spec.ts frontend/e2e-tests/admin-ui.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_6840139569648320b7c4a754609feab5