### PR TITLE
Add coupon fields to order models

### DIFF
--- a/app/models/order_models.py
+++ b/app/models/order_models.py
@@ -28,10 +28,15 @@ class OrderItem(OrderItemInDBBase):
 
 
 class OrderBase(BaseModel):
+    """Base fields shared by order models."""
+
     user_id: UUID  # Will be set from path or JWT
     address_id: UUID  # From query param - BOLA target
     credit_card_id: UUID  # From query param - BOLA target
     status: str = "pending"
+    applied_coupon_id: Optional[UUID] = None
+    applied_coupon_code: Optional[str] = None
+    discount_amount: float = Field(default=0.0, ge=0)
 
 
 class OrderCreate(BaseModel):
@@ -43,8 +48,13 @@ class OrderCreate(BaseModel):
 
 
 class OrderInDBBase(OrderBase):
+    """Representation of an order stored in the database."""
+
     order_id: UUID = Field(default_factory=uuid4)
-    total_amount: float = 0.0  # Will be calculated based on items
+    total_amount: float = Field(
+        default=0.0,
+        description="Final price of the order after applying any discount",
+    )
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -52,6 +62,8 @@ class OrderInDBBase(OrderBase):
 
 
 class Order(OrderInDBBase):
+    """Public facing order model."""
+
     items: List[OrderItem] = []
     credit_card_last_four: Optional[str] = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -1978,10 +1978,27 @@
             "format": "uuid",
             "description": "Foreign key to CreditCard used for payment"
           },
+          "applied_coupon_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the applied coupon, if any",
+            "nullable": true
+          },
+          "applied_coupon_code": {
+            "type": "string",
+            "description": "Code of the applied coupon, if any",
+            "nullable": true
+          },
+          "discount_amount": {
+            "type": "number",
+            "format": "float",
+            "description": "Discount applied to the order",
+            "default": 0.0
+          },
           "total_amount": {
             "type": "number",
             "format": "float",
-            "description": "Total amount of the order",
+            "description": "Total amount of the order after discount",
             "readOnly": true
           },
           "status": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1335,10 +1335,24 @@ components:
           type: string
           format: uuid
           description: Foreign key to CreditCard used for payment
+        applied_coupon_id:
+          type: string
+          format: uuid
+          description: Identifier of the applied coupon, if any
+          nullable: true
+        applied_coupon_code:
+          type: string
+          description: Code of the applied coupon, if any
+          nullable: true
+        discount_amount:
+          type: number
+          format: float
+          description: Discount applied to the order
+          default: 0.0
         total_amount:
           type: number
           format: float
-          description: Total amount of the order
+          description: Total amount of the order after discount
           readOnly: true
         status:
           type: string


### PR DESCRIPTION
## Summary
- add coupon fields to OrderBase and propagate to other order models
- document that `total_amount` reflects the discounted price
- update OpenAPI docs with the new attributes

## Testing
- `pytest tests/test_functional.py::test_list_orders_increases_after_creation -v`
- `pytest tests/test_functional.py::test_create_order_and_stock_deduction -v`


------
https://chatgpt.com/codex/tasks/task_b_6841c67a4ee48320985ccb02c0aa4748