### PR TITLE
Initialize coupons data

### DIFF
--- a/prepopulated_data.json
+++ b/prepopulated_data.json
@@ -570,5 +570,27 @@
       ],
       "is_protected": true
     }
+  ],
+  "coupons": [
+    {
+      "coupon_id": "11111111-1111-1111-1111-111111111111",
+      "code": "TESTCODE",
+      "discount_type": "percentage",
+      "discount_value": 10,
+      "is_active": true,
+      "usage_limit": null,
+      "expiration_date": null,
+      "is_protected": false
+    },
+    {
+      "coupon_id": "22222222-2222-2222-2222-222222222222",
+      "code": "WELCOME5",
+      "discount_type": "fixed",
+      "discount_value": 5,
+      "is_active": true,
+      "usage_limit": 100,
+      "expiration_date": null,
+      "is_protected": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- load coupons into the in-memory database
- define coupon indexes for quick lookup
- add sample coupons to prepopulated data

## Testing
- `pytest tests/test_functional.py -v`
- `pytest tests/test_vulnerabilities.py -v`


------
https://chatgpt.com/codex/tasks/task_b_6841ca00e5508320bfb4c58eb7c6622e