### PR TITLE
Add coupon functionality to checkout

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -3516,7 +3516,7 @@ function displayCheckoutItems() {
             <tfoot>
                 <tr>
                     <td colspan="3" class="text-right"><strong>Grand Total</strong></td>
-                    <td class="text-right"><strong>$${cartTotal.toFixed(2)}</strong></td>
+                    <td class="text-right"><strong id="checkout-grand-total">$${cartTotal.toFixed(2)}</strong></td>
                 </tr>
             </tfoot>
         </table>

--- a/frontend/templates/checkout.html
+++ b/frontend/templates/checkout.html
@@ -62,6 +62,14 @@
         <div id="cart-summary">
             <p class="loading-indicator">Loading cart summary...</p>
         </div>
+        <div class="coupon-section" style="margin-top:1rem;">
+            <label for="coupon-code">Coupon Code:</label>
+            <input type="text" id="coupon-code" class="form-control" placeholder="Enter coupon">
+            <button type="button" id="apply-coupon-btn" class="btn btn-secondary" style="margin-top:8px;">Apply Coupon</button>
+            <div id="discount-info" style="display:none; margin-top:8px;">
+                Discounted Total: <span id="discounted-total"></span>
+            </div>
+        </div>
     </div>
     
     <!-- Form now wraps both normal and BOLA fields -->
@@ -178,4 +186,5 @@
     {{ super() }}
     <!-- main.js (via super) calls initCheckoutPage() which sets up the page -->
     <!-- checkout.js (if you have specific BOLA UI helpers not in main.js) could be linked here or also included in main.js -->
+    <script src="{{ url_for('static', filename='js/checkout.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add coupon form to `checkout.html`
- wire `checkout.js` to POST `/apply-coupon`
- show discounted total in DOM
- expose total element id via `main.js`

## Testing
- `pytest tests/test_functional.py::test_create_order_and_stock_deduction -v`
- `pytest tests/test_vulnerabilities.py::test_bola_user_orders_access -v`


------
https://chatgpt.com/codex/tasks/task_b_6841e66902508320bbfa20027895b4ad