### PR TITLE
Sort order history newest first

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -2594,6 +2594,7 @@ async function fetchAndDisplayOrders() {
 }
 
 function renderOrders(orders, container) {
+    orders.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); // Sort orders: newest first
     if (!orders || orders.length === 0) {
         container.innerHTML = '<div class="empty-state"><i class="fas fa-receipt"></i><p>No orders found.</p></div>';
         return;


### PR DESCRIPTION
## Summary
- sort user order history by `created_at` descending

## Testing
- `npx playwright test frontend/e2e-tests/orders-ui.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_68429af4b0208320adfda47392ff7192