### PR TITLE
Introduce coupon ghost vulnerability

### DIFF
--- a/app/routers/order_router.py
+++ b/app/routers/order_router.py
@@ -18,6 +18,11 @@ from ..models.user_models import User, Address, CreditCard
 from ..models.coupon_models import Coupon
 from ..routers.user_router import get_current_user  # Reuse the dependency
 
+# --- VULNERABILITY INJECTION: Insecure cache for pending coupons ---
+# This dictionary will map a user_id to a coupon_code they've tried to apply.
+pending_coupons_cache: Dict[UUID, str] = {}
+# --- END VULNERABILITY INJECTION ---
+
 router = APIRouter(prefix="/users/{user_id}/orders", tags=["Orders"])  # Common prefix
 
 
@@ -211,6 +216,45 @@ async def create_user_order(
     new_order_db.total_amount = round(current_total_amount, 2)
     new_order_db.updated_at = datetime.now(timezone.utc)
 
+    # --- START OF VULNERABILITY INJECTION ---
+    # Check the insecure cache for a pending coupon for this user
+    if user_id in pending_coupons_cache:
+        coupon_code_to_apply = pending_coupons_cache.pop(
+            user_id
+        )  # Get and remove from cache
+        coupon = db.db_coupons_by_code.get(coupon_code_to_apply)
+        if coupon:
+            print(
+                f"VULNERABILITY: Found and applying cached coupon '{coupon.code}' to new order {new_order_db.order_id}."
+            )
+
+            # Re-apply the coupon logic here
+            if coupon.discount_type == "percentage":
+                discount = round(
+                    new_order_db.total_amount * (coupon.discount_value / 100), 2
+                )
+            else:
+                discount = coupon.discount_value
+
+            if discount > new_order_db.total_amount:
+                discount = new_order_db.total_amount
+
+            new_order_db.total_amount = round(new_order_db.total_amount - discount, 2)
+            new_order_db.applied_coupon_id = coupon.coupon_id
+            new_order_db.applied_coupon_code = coupon.code
+            new_order_db.discount_amount = round(discount, 2)
+
+            # Also increment usage count on the actual coupon
+            coupon.usage_count += 1
+            if (
+                coupon.is_protected
+                and coupon.usage_limit is not None
+                and coupon.usage_count >= coupon.usage_limit
+            ):
+                coupon.usage_count = 0
+            coupon.updated_at = datetime.now(timezone.utc)
+    # --- END OF VULNERABILITY INJECTION ---
+
     # Prepare response model
     order_response = Order.model_validate(new_order_db)
     order_response.items = [
@@ -267,21 +311,49 @@ async def apply_coupon_to_order(
     coupon_code: str = Query(...),
     current_user: TokenData = Depends(get_current_user),
 ):
-    """Apply a coupon to an existing order."""
-    order_db = db.db_orders_by_id.get(order_id)
-    if not order_db or order_db.user_id != user_id:
-        path_user_exists = db.db_users_by_id.get(user_id)
-        if not path_user_exists:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"User with ID {user_id} not found.",
-            )
+    """
+    Apply a coupon to an existing order.
+    INTENTIONALLY VULNERABLE VERSION: If the order doesn't exist, this function
+    will insecurely cache the coupon intent for the user, which can be
+    exploited by the next order creation.
+    """
+    if current_user.user_id != user_id:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Order with ID {order_id} not found for user {user_id}.",
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to perform this action for the specified user",
         )
 
-    if current_user.user_id != order_db.user_id:
+    order_db = db.db_orders_by_id.get(order_id)
+
+    # --- START OF VULNERABLE LOGIC ---
+    if not order_db:
+        # VULNERABILITY: Order does not exist. Instead of failing, we cache the coupon.
+        coupon = db.db_coupons_by_code.get(coupon_code)
+        if coupon and coupon.is_active:
+            print(
+                f"VULNERABILITY: Order {order_id} not found. Caching coupon '{coupon_code}' for user {user_id}."
+            )
+            pending_coupons_cache[user_id] = coupon_code
+            # Lie to the attacker and pretend it worked by returning a fake, minimal order object.
+            fake_order_response = {
+                "order_id": order_id,
+                "user_id": user_id,
+                "status": "pending_confirmation",
+                "applied_coupon_code": coupon_code,
+                "total_amount": -1.0,
+                "address_id": "00000000-0000-0000-0000-000000000000",
+                "credit_card_id": "00000000-0000-0000-0000-000000000000",
+                "items": [],
+            }
+            return Order.model_validate(fake_order_response)
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Coupon not found or inactive",
+            )
+    # --- END OF VULNERABLE LOGIC ---
+
+    if order_db.user_id != user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to modify this order",
@@ -302,20 +374,12 @@ async def apply_coupon_to_order(
     coupon = db.db_coupons_by_code.get(coupon_code)
     if not coupon or not coupon.is_active:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Coupon not found or inactive",
-        )
-
-    if coupon.expiration_date and coupon.expiration_date < datetime.now(timezone.utc):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Coupon has expired",
+            status_code=status.HTTP_404_NOT_FOUND, detail="Coupon not found or inactive"
         )
 
     if coupon.usage_limit is not None and coupon.usage_count >= coupon.usage_limit:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Coupon usage limit reached",
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Coupon usage limit reached"
         )
 
     if coupon.discount_type == "percentage":
@@ -333,8 +397,6 @@ async def apply_coupon_to_order(
     order_db.updated_at = datetime.now(timezone.utc)
 
     coupon.usage_count += 1
-    # --- ADDED LOGIC: Reset protected, limited-use coupons after use ---
-    # This ensures demo flows that rely on these coupons don't break after one use.
     if (
         coupon.is_protected
         and coupon.usage_limit is not None
@@ -343,12 +405,10 @@ async def apply_coupon_to_order(
         print(
             f"INFO: Protected coupon '{coupon.code}' reached its usage limit. Resetting usage count to 0 for demo stability."
         )
-        coupon.usage_count = 0  # Reset the count immediately
-    # --- END ADDED LOGIC ---
+        coupon.usage_count = 0
     coupon.updated_at = datetime.now(timezone.utc)
 
     items_for_this_order = db.db_order_items_by_order_id.get(order_db.order_id, [])
-
     order_response = Order.model_validate(order_db)
     order_response.items = [
         OrderItem.model_validate(item) for item in items_for_this_order


### PR DESCRIPTION
## Summary
- add insecure cache for pending coupons
- introduce intentionally vulnerable apply coupon endpoint
- apply cached coupons when creating orders

## Testing
- `pytest tests/test_vulnerabilities.py -k "test_coupon_ghost_application_vulnerability" -v` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_684348276d30832084c7d54d3b319108