### PR TITLE
Fix coupon single-use logic

### DIFF
--- a/app/routers/order_router.py
+++ b/app/routers/order_router.py
@@ -397,15 +397,6 @@ async def apply_coupon_to_order(
     order_db.updated_at = datetime.now(timezone.utc)
 
     coupon.usage_count += 1
-    if (
-        coupon.is_protected
-        and coupon.usage_limit is not None
-        and coupon.usage_count >= coupon.usage_limit
-    ):
-        print(
-            f"INFO: Protected coupon '{coupon.code}' reached its usage limit. Resetting usage count to 0 for demo stability."
-        )
-        coupon.usage_count = 0
     coupon.updated_at = datetime.now(timezone.utc)
 
     items_for_this_order = db.db_order_items_by_order_id.get(order_db.order_id, [])


### PR DESCRIPTION
## Summary
- remove logic resetting usage_count for protected coupons

## Testing
- `pytest tests/test_functional.py::test_apply_coupon_to_order -v`


------
https://chatgpt.com/codex/tasks/task_b_6844983a4d7c83209187985160c4928a