### PR TITLE
Fix BOLA demo fields toggle

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -1378,7 +1378,7 @@ function initCheckoutPage() {
                  }
             }
 
-            if (!this.checked) { 
+            if (!this.checked) {
                 const userSearchResults = document.getElementById('user-search-results');
                 if (userSearchResults) userSearchResults.style.display = 'none';
                 
@@ -1392,6 +1392,10 @@ function initCheckoutPage() {
                 if (theftPreview) {
                     theftPreview.innerHTML = '<div class="no-theft-selected alert alert-secondary">Enable BOLA exploit and select a target card to see preview.</div>';
                 }
+            }
+
+            if (typeof updateUIVulnerabilityFeaturesDisplay === 'function') {
+                updateUIVulnerabilityFeaturesDisplay();
             }
         });
     }


### PR DESCRIPTION
## Summary
- call `updateUIVulnerabilityFeaturesDisplay` when toggling BOLA checkbox on checkout page

## Testing
- `pytest tests/test_functional.py -v` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest tests/test_vulnerabilities.py -v` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6845550f348c832097b19b514e6b54d9