### PR TITLE
Enable gzip and caching headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,10 @@ server {
     # Include standard MIME types so browsers receive correct headers
     include /etc/nginx/mime.types;
 
+    # Enable gzip compression for common text-based assets
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json application/xml text/javascript;
+
     # --- Backend Specific Documentation Paths & Files ---
     location /docs {
         proxy_pass http://localhost:8000/docs;
@@ -50,6 +54,9 @@ server {
     # --- Static Files for Frontend ---
     location /static {
         alias /app/frontend/static; # Path to your static files inside the Docker container
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        try_files $uri =404;
     }
 
     # --- Frontend Flask Application (Catch-all) ---


### PR DESCRIPTION
## Summary
- enable gzip compression for text assets
- add caching headers for /static assets

## Testing
- `pytest tests/test_functional.py::test_register_and_login -v`
- `curl -H "Accept-Encoding: gzip" -I http://localhost/static/css/style.css`

------
https://chatgpt.com/codex/tasks/task_b_6849b2bdf5d08320b4a75b03efda5f26