### PR TITLE
Set default uvicorn workers to 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 80
 # Define environment variable
 ENV PYTHONPATH=/app
 # Default worker count can be overridden at runtime
-ENV UVICORN_WORKERS=4
+ENV UVICORN_WORKERS=1
 
 # Command to run supervisor, which will manage both services
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ This often manifests as Mass Assignment or Parameter Pollution, where users can 
     ```
     The API will be accessible at `http://localhost:8000`.
 
-    Set `UVICORN_WORKERS` to control the number of worker processes:
+    The container defaults to a single Uvicorn worker. Set `UVICORN_WORKERS`
+    if you need additional workers:
     ```sh
-    docker run -d -p 8000:80 -e UVICORN_WORKERS=4 \
+    docker run -d -p 8000:80 -e UVICORN_WORKERS=2 \
       --name radware-vuln-api vulnerable-ecommerce-api
     ```
 


### PR DESCRIPTION
## Summary
- set `UVICORN_WORKERS` default to 1 in Dockerfile
- clarify README that the container defaults to one worker and show example override

## Testing
- `pytest tests/test_functional.py::test_register_and_login -v`

------
https://chatgpt.com/codex/tasks/task_b_6862794118e883209e4fdb4e8edfcd23