### PR TITLE
Add SQLAlchemy install and dbsync program

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ RUN apt-get update && apt-get install -y nginx supervisor
 
 # Set the working directory in the container
 WORKDIR /app
+RUN mkdir -p /app/data && chmod 777 /app/data
 
 # Copy the dependencies file to the working directory
 COPY requirements.txt .
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install Flask Jinja2 requests "Werkzeug<2.3" python-json-logger
+RUN pip install Flask Jinja2 requests SQLAlchemy "Werkzeug<2.3" python-json-logger
 
 # Copy the backend and frontend code
 COPY ./app /app/app

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -33,3 +33,13 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:dbsync]
+command=/bin/sh -c 'if [ -n "$DB_SYNC_PEER" ]; then python -m app.sync; else sleep 3600; fi'
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary
- install SQLAlchemy and requests in Dockerfile
- create writable `/app/data` directory
- add `dbsync` program in `supervisord.conf` to run when `DB_SYNC_PEER` is set

## Testing
- `pytest tests/test_functional.py::test_register_and_login -v`

------
https://chatgpt.com/codex/tasks/task_b_6873d31475188320b51fe303be7181de