### PR TITLE
Configure DB backend via env var

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,35 @@
+"""Application package initialization."""
+
+from __future__ import annotations
+
+import os
+
+from .db import set_backend
+from .db_memory import MemoryBackend
+from .db_sqlite import SQLiteBackend
+
+
+def _choose_backend_from_env() -> object:
+    """Select and initialize the DB backend based on environment variables."""
+
+    db_mode = os.getenv("DB_MODE", "memory").lower()
+    if db_mode == "external":
+        db_url = os.getenv("DB_URL")
+        if not db_url:
+            raise ValueError("DB_URL must be set when DB_MODE=external")
+        backend = SQLiteBackend(db_url)
+    elif db_mode == "sqlite":
+        backend = SQLiteBackend(None)
+    elif db_mode == "memory":
+        backend = MemoryBackend()
+    else:
+        raise ValueError(f"Unsupported DB_MODE '{db_mode}'")
+
+    if hasattr(backend, "initialize_database_from_json"):
+        backend.initialize_database_from_json()
+
+    return backend
+
+
+set_backend(_choose_backend_from_env())
+

--- a/app/db.py
+++ b/app/db.py
@@ -1,33 +1,18 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from .db_base import DatabaseBackend
 from .db_memory import MemoryBackend
-from .db_sqlite import SQLiteBackend
 
-# Map supported backend modes to their implementations
-_BACKENDS = {
-    "memory": MemoryBackend,
-    "sqlite": SQLiteBackend,
-}
+_backend: DatabaseBackend = MemoryBackend()
 
-# Determine backend based on DB_MODE
-_db_mode = os.getenv("DB_MODE", "memory").lower()
-if _db_mode == "external":
-    db_url = os.getenv("DB_URL")
-    if not db_url:
-        raise ValueError("DB_URL must be set when DB_MODE=external")
-    _backend = SQLiteBackend(db_url)
-else:
-    _backend_cls = _BACKENDS.get(_db_mode)
-    if _backend_cls is None:
-        raise ValueError(f"Unsupported DB_MODE '{_db_mode}'")
-    _backend = _backend_cls()
-# initialize using default prepopulated data if available
-if hasattr(_backend, "initialize_database_from_json"):
-    _backend.initialize_database_from_json()
+
+def set_backend(backend: DatabaseBackend) -> None:
+    """Set the global backend implementation."""
+
+    global _backend
+    _backend = backend
 
 
 def __getattr__(name: str) -> Any:  # pragma: no cover - thin delegation


### PR DESCRIPTION
## Summary
- set up database backend in `app/__init__.py` using `DB_MODE`
- expose a `set_backend` helper in `app/db.py`
- default to memory backend but allow switching from package init
- ensure selected backend loads `prepopulated_data.json` when empty

## Testing
- `pytest tests/test_functional.py::test_register_and_login -v`
- `pytest tests/test_functional.py::test_list_products -v`
- `pytest tests/test_vulnerabilities.py::test_bola_user_details_access -v`


------
https://chatgpt.com/codex/tasks/task_b_6873d823e7f483208383e059c0b186e8