### PR TITLE
Add sqlite testing fixtures

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -108,6 +108,19 @@ Run with verbose output:
 pytest tests/ -v
 ```
 
+### Using the SQLite Backend
+
+The default tests use the in‑memory database. To exercise the
+SQLite backend, set ``DB_MODE=sqlite`` before running pytest. Optionally
+point ``DB_SQLITE_PATH`` at an empty file location:
+
+```sh
+DB_MODE=sqlite DB_SQLITE_PATH=/tmp/test_db.sqlite pytest tests/test_functional.py
+```
+
+The ``sqlite_test_client`` fixture in ``tests/conftest.py`` can also be
+used for custom scenarios.
+
 ### Automated Verification
 
 A verification script is provided to automate the testing process:


### PR DESCRIPTION
## Summary
- add sqlite_test_client fixture
- ignore duplicate coupon inserts for sqlite backend
- describe sqlite usage in README_TESTING

## Testing
- `pytest tests/test_functional.py::test_register_and_login -q`
- `DB_MODE=sqlite DB_SQLITE_PATH=/tmp/test_db.sqlite pytest tests/test_functional.py::test_register_and_login -q` *(fails: AttributeError: 'SQLiteBackend' object has no attribute 'db_users_by_username')*

------
https://chatgpt.com/codex/tasks/task_b_6873f4fe374883208c809e29ae5eb0f2