### PR TITLE
Fix docs to use provided OpenAPI schema

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 import os
+import yaml
 from .routers import (
     auth_router,
     user_router,
@@ -105,6 +106,22 @@ app = FastAPI(
     description="An intentionally vulnerable e-commerce API designed to demonstrate business logic attacks, focusing on path and query parameters.",
     version="1.0.0",
 )
+
+# Use the pre-generated OpenAPI specification from openapi.yaml
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def custom_openapi() -> dict:
+    """Load the OpenAPI schema from the repository's openapi.yaml file."""
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_path = os.path.join(BASE_DIR, "openapi.yaml")
+    with open(openapi_path, "r") as f:
+        app.openapi_schema = yaml.safe_load(f)
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 # Add the custom middleware to your FastAPI app
 if os.getenv("ENABLE_ACCESS_LOG", "false").lower() == "true":

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -599,12 +599,8 @@ def test_protected_bob_card_general_update(
     db.initialize_database_from_json()
 
 
-def test_products_cache_expiry(test_client, monkeypatch):
+def test_products_refresh_after_modification(test_client):
     from app import db
-    from app.routers import product_router as pr
-
-    pr.cache.clear()
-    monkeypatch.setattr(pr, "CACHE_TTL", 1)
 
     resp1 = test_client.get("/api/products")
     assert resp1.status_code == 200
@@ -614,11 +610,6 @@ def test_products_cache_expiry(test_client, monkeypatch):
     db.db["products"].append(new_prod)
     db.db_products_by_id[new_prod.product_id] = new_prod
 
-    resp_cached = test_client.get("/api/products")
-    assert resp_cached.status_code == 200
-    assert len(resp_cached.json()) == initial_count
-
-    time.sleep(1.1)
     resp_after = test_client.get("/api/products")
     assert resp_after.status_code == 200
     assert len(resp_after.json()) == initial_count + 1
@@ -626,12 +617,8 @@ def test_products_cache_expiry(test_client, monkeypatch):
     db.initialize_database_from_json()
 
 
-def test_products_cache_invalidation_on_modify(test_client, monkeypatch):
+def test_products_modify_operations_reflect_immediately(test_client):
     from app import db
-    from app.routers import product_router as pr
-
-    pr.cache.clear()
-    monkeypatch.setattr(pr, "CACHE_TTL", 60)
 
     resp = test_client.get("/api/products")
     count = len(resp.json())
@@ -660,12 +647,8 @@ def test_products_cache_invalidation_on_modify(test_client, monkeypatch):
     db.initialize_database_from_json()
 
 
-def test_product_search_cache_expiry(test_client, monkeypatch):
+def test_product_search_updates_reflect_immediately(test_client):
     from app import db
-    from app.routers import product_router as pr
-
-    pr.cache.clear()
-    monkeypatch.setattr(pr, "CACHE_TTL", 1)
     query = "CacheSearch"
 
     resp = test_client.get("/api/products/search", params={"name": query})
@@ -676,11 +659,6 @@ def test_product_search_cache_expiry(test_client, monkeypatch):
     db.db["products"].append(new_p)
     db.db_products_by_id[new_p.product_id] = new_p
 
-    resp_cached = test_client.get("/api/products/search", params={"name": query})
-    assert resp_cached.status_code == 200
-    assert resp_cached.json() == []
-
-    time.sleep(1.1)
     resp_after = test_client.get("/api/products/search", params={"name": query})
     assert resp_after.status_code == 200
     assert len(resp_after.json()) == 1


### PR DESCRIPTION
## Summary
- load OpenAPI schema from `openapi.yaml` so `/docs` reflects the latest spec
- update functional tests after cache removal

## Testing
- `pytest tests/test_functional.py -k "refresh_after_modification or modify_operations_reflect_immediately or product_search_updates_reflect_immediately" -v`
- `pytest tests/test_functional.py -v`
- `pytest tests/test_vulnerabilities.py -v`


------
https://chatgpt.com/codex/tasks/task_b_68756beee4d08320b8dd959a47cdcfa2